### PR TITLE
[codex] Add Doubao ASR provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -656,14 +656,14 @@ APP_CONFIG = {
 
 2. **如何切换 ASR 语音识别模型？**
 
-    仅 `openclaw.input_mode = "local_asr"` 时，本地离线 ASR 配置才会生效。在 `config.py` 中配置：
+    仅 `openclaw.input_mode = "local_asr"` 时，ASR 配置才会生效。在 `config.py` 中配置：
 
     ```python
     APP_CONFIG = {
         "asr": {
-            "model": "sense_voice",  # "sense_voice"（默认）/ "paraformer" / "fire_red_asr"
-            "int8": True,               # 优先加载 INT8 量化模型
-            # "model_dir": "sherpa-onnx-fire-red-asr-xxx",  # 可选：显式指定模型目录
+            "model": "sense_voice",  # "sense_voice"（默认）/ "paraformer" / "fire_red_asr" / "doubao"
+            "int8": True,            # 本地模型优先加载 INT8 量化模型
+            # "model_dir": "sherpa-onnx-fire-red-asr-xxx",  # 可选：显式指定本地模型目录
         },
     }
     ```
@@ -673,8 +673,40 @@ APP_CONFIG = {
     | `sense_voice` | [SenseVoice-Small](https://github.com/FunAudioLLM/SenseVoice) | 多任务语音理解模型，支持中/英/日/韩/粤五语种自动识别，附带语言检测、ITN 和情感识别，推理极快 |
     | `paraformer` | [Paraformer-Trilingual](https://github.com/modelscope/FunASR) | 专注语音转写的工业级非自回归模型，支持中文/英文/粤语，中文识别精度高 |
     | `fire_red_asr` | [FireRedASR](https://github.com/FireRedTeam/FireRedASR) | FireRedASR 是一系列开源的工业级自动语音识别 (ASR) 模型，支持普通话、汉语方言和英语，在公开的普通话 ASR 基准测试中达到了新的最先进水平 (SOTA)，同时还提供了出色的歌词识别能力。 |
+    | `doubao` | [火山引擎豆包语音识别](https://www.volcengine.com/docs/6561/1354868?lang=zh) | 云端录音文件识别，支持标准版和极速版，需要配置火山引擎 App Key / Access Key |
 
-    将对应模型目录放到 `core/models/`（Docker 部署放 `./models/`）下即可，不配置默认使用 `sense_voice`。
+    使用本地模型时，将对应模型目录放到 `core/models/`（Docker 部署放 `./models/`）下即可，不配置默认使用 `sense_voice`。
+
+    使用豆包 ASR 时，将 `model` 改为 `"doubao"`，并填写 `asr.doubao`：
+
+    ```python
+    APP_CONFIG = {
+        "asr": {
+            "model": "doubao",
+            "doubao": {
+                # "standard": 录音文件识别标准版，调用 /submit + /query
+                # "flash": 录音文件极速版，调用 /recognize/flash
+                "mode": "standard",
+                "app_key": "你的 App Key",
+                "access_key": "你的 Access Key",
+                # 火山 X-Api-Resource-Id：
+                # standard 可选：
+                #   "volc.bigasr.auc"  - 豆包录音文件识别模型 1.0
+                #   "volc.seedasr.auc" - 豆包录音文件识别模型 2.0
+                # flash 可选：
+                #   "volc.bigasr.auc_turbo" - 录音文件极速版
+                "resource_id": "volc.seedasr.auc",
+                "language": "",
+                "submit_timeout": 10,
+                "query_timeout": 10,
+                "poll_interval": 0.5,
+                "max_wait_seconds": 20,
+            },
+        },
+    }
+    ```
+
+    `standard` 模式会把本地 PCM 封装为 wav 后以 base64 提交到标准版接口；如果你的火山账号不支持该请求形式，可切换为 `flash` 并将 `resource_id` 改为 `"volc.bigasr.auc_turbo"`。
 
 3. **如何打断 AI 的回答？**
 

--- a/config.py
+++ b/config.py
@@ -168,12 +168,31 @@ APP_CONFIG = {
         "gain": 1.0,
     },
     "asr": {
-        # 支持 "sense_voice"（默认）、"paraformer" 或 "fire_red_asr"
+        # 支持 "sense_voice"（默认）、"paraformer"、"fire_red_asr" 或 "doubao"
         "model": "sense_voice",
-        # 是否优先使用 INT8 量化模型
+        # 是否优先使用 INT8 量化模型（仅本地模型生效）
         "int8": True,
-        # 可选：显式指定 core/models/ 下的模型目录名
+        # 可选：显式指定 core/models/ 下的模型目录名（仅本地模型生效）
         # "model_dir": "",
+        "doubao": {
+            # "standard": 录音文件识别标准版，调用 /submit + /query
+            # "flash": 录音文件极速版，调用 /recognize/flash
+            "mode": "standard",
+            "app_key": "你的 App Key",
+            "access_key": "你的 Access Key",
+            # 火山 X-Api-Resource-Id：
+            # standard 可选：
+            #   "volc.bigasr.auc"  - 豆包录音文件识别模型 1.0
+            #   "volc.seedasr.auc" - 豆包录音文件识别模型 2.0
+            # flash 可选：
+            #   "volc.bigasr.auc_turbo" - 录音文件极速版
+            "resource_id": "volc.seedasr.auc",
+            "language": "",
+            "submit_timeout": 10,
+            "query_timeout": 10,
+            "poll_interval": 0.5,
+            "max_wait_seconds": 20,
+        },
     },
     "xiaozhi": {
         "OTA_URL": "http://127.0.0.1:8003/xiaozhi/ota/",

--- a/core/app.py
+++ b/core/app.py
@@ -187,10 +187,10 @@ class MainApp:
                     "local_asr",
                 )
                 if input_mode == "local_asr":
-                    from core.services.audio.asr.sherpa import SherpaASR
+                    from core.services.audio.asr import ASRService
 
                     threading.Thread(
-                        target=SherpaASR._ensure_loaded,
+                        target=ASRService.ensure_loaded,
                         daemon=True,
                         name="asr-warmup",
                     ).start()

--- a/core/openclaw_conversation.py
+++ b/core/openclaw_conversation.py
@@ -23,7 +23,7 @@ import open_xiaoai_server
 
 from core.openclaw import OpenClawManager
 from core.ref import get_speaker, get_vad
-from core.services.audio.asr.sherpa import SherpaASR
+from core.services.audio.asr import ASRService
 from core.utils.config import ConfigManager
 
 _NOTIFY_SOUND_PATH = os.path.join(
@@ -216,7 +216,7 @@ class OpenClawConversationController:
         )
 
         # 2. ASR: convert speech to text
-        text = SherpaASR.asr(speech_bytes, sample_rate=16000)
+        text = ASRService.asr(speech_bytes, sample_rate=16000)
         if not text:
             logger.debug("ASR empty, retrying", module="OpenClaw Conv")
             return "continue"

--- a/core/services/audio/asr/__init__.py
+++ b/core/services/audio/asr/__init__.py
@@ -1,3 +1,13 @@
-from core.services.audio.asr.sherpa import SherpaASR
+__all__ = ["ASRService", "SherpaASR"]
 
-__all__ = ["SherpaASR"]
+
+def __getattr__(name):
+    if name == "ASRService":
+        from core.services.audio.asr.service import ASRService
+
+        return ASRService
+    if name == "SherpaASR":
+        from core.services.audio.asr.sherpa import SherpaASR
+
+        return SherpaASR
+    raise AttributeError(name)

--- a/core/services/audio/asr/doubao.py
+++ b/core/services/audio/asr/doubao.py
@@ -1,0 +1,235 @@
+"""Doubao Volcano Engine ASR provider.
+
+This provider keeps the same input contract as the local Sherpa ASR:
+raw PCM int16 mono bytes in, recognized text out.
+"""
+
+import base64
+import io
+import time
+import uuid
+import wave
+from typing import Any
+
+from core.utils.logger import logger
+
+
+class _DoubaoASR:
+    """Volcano Engine Doubao recorded-file ASR client."""
+
+    STANDARD_SUBMIT_URL = "https://openspeech.bytedance.com/api/v3/auc/bigmodel/submit"
+    STANDARD_QUERY_URL = "https://openspeech.bytedance.com/api/v3/auc/bigmodel/query"
+    FLASH_RECOGNIZE_URL = (
+        "https://openspeech.bytedance.com/api/v3/auc/bigmodel/recognize/flash"
+    )
+
+    VALID_MODES = {"standard", "flash"}
+
+    def _cfg(self, key: str, default: Any = None) -> Any:
+        from core.utils.config import ConfigManager
+
+        return ConfigManager.instance().get_app_config(f"asr.doubao.{key}", default)
+
+    def _mode(self) -> str:
+        mode = str(self._cfg("mode", "standard")).strip().lower()
+        if mode not in self.VALID_MODES:
+            raise ValueError(
+                f"Unknown asr.doubao.mode={mode!r}. Supported: standard, flash"
+            )
+        return mode
+
+    def _timeout(self, key: str, default: float) -> float:
+        try:
+            return float(self._cfg(key, default))
+        except (TypeError, ValueError):
+            return default
+
+    def _headers(self, request_id: str, include_sequence: bool = False) -> dict[str, str]:
+        app_key = str(self._cfg("app_key", "")).strip()
+        access_key = str(self._cfg("access_key", "")).strip()
+        resource_id = str(self._cfg("resource_id", "")).strip()
+
+        if not app_key:
+            raise ValueError("Missing asr.doubao.app_key")
+        if not access_key:
+            raise ValueError("Missing asr.doubao.access_key")
+        if not resource_id:
+            raise ValueError("Missing asr.doubao.resource_id")
+
+        headers = {
+            "Content-Type": "application/json",
+            "X-Api-App-Key": app_key,
+            "X-Api-Access-Key": access_key,
+            "X-Api-Resource-Id": resource_id,
+            "X-Api-Request-Id": request_id,
+        }
+        if include_sequence:
+            headers["X-Api-Sequence"] = "-1"
+        return headers
+
+    def _build_audio(self, pcm_bytes: bytes, sample_rate: int) -> dict[str, Any]:
+        wav_bytes = self._pcm_to_wav(pcm_bytes, sample_rate)
+        audio: dict[str, Any] = {
+            "format": "wav",
+            "data": base64.b64encode(wav_bytes).decode("ascii"),
+        }
+
+        language = str(self._cfg("language", "") or "").strip()
+        if language:
+            audio["language"] = language
+        return audio
+
+    @staticmethod
+    def _pcm_to_wav(pcm_bytes: bytes, sample_rate: int) -> bytes:
+        buffer = io.BytesIO()
+        with wave.open(buffer, "wb") as wav_file:
+            wav_file.setnchannels(1)
+            wav_file.setsampwidth(2)
+            wav_file.setframerate(sample_rate)
+            wav_file.writeframes(pcm_bytes)
+        return buffer.getvalue()
+
+    def _build_payload(self, pcm_bytes: bytes, sample_rate: int) -> dict[str, Any]:
+        return {
+            "user": {"uid": str(self._cfg("uid", self._cfg("app_key", "")))},
+            "audio": self._build_audio(pcm_bytes, sample_rate),
+            "request": {
+                "model_name": "bigmodel",
+                "enable_itn": True,
+            },
+        }
+
+    @staticmethod
+    def _header_status(response: Any) -> tuple[str, str, str]:
+        return (
+            response.headers.get("X-Api-Status-Code", ""),
+            response.headers.get("X-Api-Message", ""),
+            response.headers.get("X-Tt-Logid", ""),
+        )
+
+    def _raise_for_api_error(self, response: Any, action: str) -> None:
+        status_code, message, logid = self._header_status(response)
+        body = response.text[:500] if response.text else ""
+        raise RuntimeError(
+            f"Doubao ASR {action} failed: http={response.status_code}, "
+            f"status={status_code}, message={message}, logid={logid}, body={body}"
+        )
+
+    def _extract_text(self, data: dict[str, Any]) -> str:
+        result = data.get("result")
+        if isinstance(result, dict):
+            text = result.get("text")
+            if isinstance(text, str):
+                return text.strip()
+        if isinstance(result, list):
+            return "".join(
+                item.get("text", "")
+                for item in result
+                if isinstance(item, dict)
+            ).strip()
+        return ""
+
+    def asr(self, pcm_bytes: bytes, sample_rate: int = 16000) -> str:
+        mode = self._mode()
+        if mode == "standard":
+            return self._recognize_standard(pcm_bytes, sample_rate)
+        return self._recognize_flash(pcm_bytes, sample_rate)
+
+    def _recognize_standard(self, pcm_bytes: bytes, sample_rate: int) -> str:
+        import requests
+
+        request_id = str(uuid.uuid4())
+        payload = self._build_payload(pcm_bytes, sample_rate)
+        submit_timeout = self._timeout("submit_timeout", 10)
+        query_timeout = self._timeout("query_timeout", 10)
+        poll_interval = self._timeout("poll_interval", 0.5)
+        max_wait_seconds = self._timeout("max_wait_seconds", 20)
+
+        logger.asr_event(
+            "Doubao ASR submit",
+            f"mode=standard, request_id={request_id}",
+        )
+
+        response = requests.post(
+            self.STANDARD_SUBMIT_URL,
+            headers=self._headers(request_id, include_sequence=True),
+            json=payload,
+            timeout=submit_timeout,
+        )
+        status_code, message, logid = self._header_status(response)
+        logger.asr_event(
+            "Doubao ASR submit response",
+            f"status={status_code}, message={message}, logid={logid}",
+        )
+        if response.status_code != 200 or status_code != "20000000":
+            self._raise_for_api_error(response, "standard submit")
+
+        deadline = time.monotonic() + max_wait_seconds
+        while time.monotonic() < deadline:
+            time.sleep(poll_interval)
+            query_response = requests.post(
+                self.STANDARD_QUERY_URL,
+                headers=self._headers(request_id),
+                json={},
+                timeout=query_timeout,
+            )
+            status_code, message, logid = self._header_status(query_response)
+            logger.asr_event(
+                "Doubao ASR query response",
+                f"status={status_code}, message={message}, logid={logid}",
+            )
+
+            if query_response.status_code != 200:
+                self._raise_for_api_error(query_response, "standard query")
+            if status_code == "20000000":
+                text = self._extract_text(query_response.json())
+                logger.debug(f"[ASR] Doubao recognized: {text}", module="ASR")
+                return text
+            if status_code in {"20000001", "20000002"}:
+                continue
+            if status_code == "20000003":
+                logger.debug("[ASR] Doubao detected silent audio", module="ASR")
+                return ""
+            self._raise_for_api_error(query_response, "standard query")
+
+        raise TimeoutError(
+            f"Doubao ASR standard query timed out after {max_wait_seconds}s, "
+            f"request_id={request_id}"
+        )
+
+    def _recognize_flash(self, pcm_bytes: bytes, sample_rate: int) -> str:
+        import requests
+
+        request_id = str(uuid.uuid4())
+        payload = self._build_payload(pcm_bytes, sample_rate)
+        submit_timeout = self._timeout("submit_timeout", 10)
+
+        logger.asr_event(
+            "Doubao ASR recognize",
+            f"mode=flash, request_id={request_id}",
+        )
+
+        response = requests.post(
+            self.FLASH_RECOGNIZE_URL,
+            headers=self._headers(request_id, include_sequence=True),
+            json=payload,
+            timeout=submit_timeout,
+        )
+        status_code, message, logid = self._header_status(response)
+        logger.asr_event(
+            "Doubao ASR recognize response",
+            f"status={status_code}, message={message}, logid={logid}",
+        )
+
+        if response.status_code != 200 or status_code != "20000000":
+            if status_code == "20000003":
+                logger.debug("[ASR] Doubao detected silent audio", module="ASR")
+                return ""
+            self._raise_for_api_error(response, "flash recognize")
+
+        text = self._extract_text(response.json())
+        logger.debug(f"[ASR] Doubao recognized: {text}", module="ASR")
+        return text
+
+
+DoubaoASR = _DoubaoASR()

--- a/core/services/audio/asr/service.py
+++ b/core/services/audio/asr/service.py
@@ -1,0 +1,33 @@
+"""ASR provider selector."""
+
+from core.services.audio.asr.doubao import DoubaoASR
+from core.services.audio.asr.sherpa import SherpaASR
+from core.utils.config import ConfigManager
+
+
+class _ASRService:
+    """Dispatch ASR requests to local Sherpa models or Doubao cloud ASR."""
+
+    DOUBAO_MODEL = "doubao"
+
+    def _model(self) -> str:
+        model = ConfigManager.instance().get_app_config("asr.model", "sense_voice")
+        return str(model).strip().lower()
+
+    def uses_doubao(self) -> bool:
+        return self._model() == self.DOUBAO_MODEL
+
+    def should_warmup_local_model(self) -> bool:
+        return not self.uses_doubao()
+
+    def ensure_loaded(self) -> None:
+        if self.should_warmup_local_model():
+            SherpaASR._ensure_loaded()
+
+    def asr(self, pcm_bytes: bytes, sample_rate: int = 16000) -> str:
+        if self.uses_doubao():
+            return DoubaoASR.asr(pcm_bytes, sample_rate=sample_rate)
+        return SherpaASR.asr(pcm_bytes, sample_rate=sample_rate)
+
+
+ASRService = _ASRService()

--- a/tests/test_doubao_asr.py
+++ b/tests/test_doubao_asr.py
@@ -1,0 +1,27 @@
+import base64
+import wave
+from io import BytesIO
+
+from core.services.audio.asr.doubao import _DoubaoASR
+
+
+def test_pcm_to_wav_wraps_int16_mono_audio():
+    pcm = (b"\x01\x00\xff\x7f") * 4
+
+    wav_bytes = _DoubaoASR._pcm_to_wav(pcm, 16000)
+
+    with wave.open(BytesIO(wav_bytes), "rb") as wav_file:
+        assert wav_file.getnchannels() == 1
+        assert wav_file.getsampwidth() == 2
+        assert wav_file.getframerate() == 16000
+        assert wav_file.readframes(wav_file.getnframes()) == pcm
+
+    assert base64.b64decode(base64.b64encode(wav_bytes)) == wav_bytes
+
+
+def test_extract_text_supports_dict_and_list_results():
+    client = _DoubaoASR()
+
+    assert client._extract_text({"result": {"text": " 你好 "}}) == "你好"
+    assert client._extract_text({"result": [{"text": "你"}, {"text": "好"}]}) == "你好"
+    assert client._extract_text({"result": {}}) == ""


### PR DESCRIPTION
﻿## Summary
- 新增火山引擎豆包 ASR provider，支持 `standard` 和 `flash` 两种模式
- 选择 `local_asr` 时，支持通过配置 `asr.model = "doubao"` 切换到豆包在线语音识别
- 在 `config.py` 和 README 中补充豆包 ASR 配置示例
