### PR TITLE
feat: 添加 OpenAI-compatible TTS / MLX-Audio TTS provider

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,6 +27,7 @@ open-xiaoai-bridge/
 │   ├── services/
 │   │   ├── speaker.py             # SpeakerManager 音箱硬件控制
 │   │   ├── api_server.py          # HTTP REST API（aiohttp）
+│   │   ├── tts/router.py           # 统一 TTS provider 路由与播放
 │   │   ├── audio/
 │   │   │   ├── stream.py          # GlobalStream 全局音频流（多路输入广播）
 │   │   │   ├── codec.py           # 音频编解码
@@ -34,7 +35,8 @@ open-xiaoai-bridge/
 │   │   │   ├── kws/sherpa.py      # Sherpa KWS 关键词唤醒
 │   │   │   └── asr/sherpa.py      # Sherpa ASR 离线语音识别（SenseVoice）
 │   │   ├── tts/doubao.py          # 豆包 TTS 客户端（火山引擎）
-│   │   ├── tts/mlx_audio.py       # MLX-Audio TTS 客户端（OpenAI-compatible 接口）
+│   │   ├── tts/openai.py           # OpenAI-compatible TTS 协议客户端
+│   │   ├── tts/mlx_audio.py        # MLX-Audio TTS provider（复用 OpenAI 协议客户端）
 │   │   └── protocols/
 │   │       ├── websocket_protocol.py  # 小智 WebSocket 协议实现
 │   │       └── typing.py              # 协议类型定义
@@ -119,7 +121,7 @@ OpenClaw 网关客户端，管理 WebSocket 连接、消息分发、自动重连
 - WebSocket ping/pong + tick 事件监控连接健康
 - 指数退避重连（初始 1s，最大 60s）
 - 请求 ID 映射 `_pending: dict[str, asyncio.Future]` 追踪响应
-- TTS 播放：`tts_speaker` 为 `"xiaoai"` 时使用小爱原生 TTS，否则使用豆包 TTS（支持流式）
+- TTS 播放：通过共享 TTS Router 选择 `xiaoai`、`doubao`、`openai` 或 `mlx_audio` provider；缺省时保持 `tts_speaker` 的旧选择逻辑
 - Rust TTS 播放使用单一活动 `playback_token`：开始新的 Rust TTS 会使旧 token 失效；`stop_tts_playback(token)` 只应由持有该 token 的调用方定向停止自己的播放
 
 **连接参数限制**:
@@ -231,7 +233,7 @@ HTTP REST API 服务器（aiohttp），端口可配（默认 9092）。
 | VAD | `audio/vad/silero.py` | Silero ONNX 语音活动检测 |
 | KWS | `audio/kws/sherpa.py` | Sherpa ONNX 关键词唤醒（信心度 2.0，阈值 0.2） |
 | ASR | `audio/asr/sherpa.py` | Sherpa SenseVoice 离线语音识别（懒加载，INT8 量化） |
-| TTS | `tts/doubao.py`, `tts/mlx_audio.py` | 豆包 TTS 与 MLX-Audio TTS（一次性/本地音频播放） |
+| TTS | `tts/openai.py`, `tts/mlx_audio.py`, `tts/doubao.py` | OpenAI-compatible TTS、MLX-Audio 与豆包 TTS（一次性/本地音频播放） |
 
 ### Rust 原生扩展 (native/)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,6 +34,7 @@ open-xiaoai-bridge/
 │   │   │   ├── kws/sherpa.py      # Sherpa KWS 关键词唤醒
 │   │   │   └── asr/sherpa.py      # Sherpa ASR 离线语音识别（SenseVoice）
 │   │   ├── tts/doubao.py          # 豆包 TTS 客户端（火山引擎）
+│   │   ├── tts/mlx_audio.py       # MLX-Audio TTS 客户端（OpenAI-compatible 接口）
 │   │   └── protocols/
 │   │       ├── websocket_protocol.py  # 小智 WebSocket 协议实现
 │   │       └── typing.py              # 协议类型定义
@@ -230,7 +231,7 @@ HTTP REST API 服务器（aiohttp），端口可配（默认 9092）。
 | VAD | `audio/vad/silero.py` | Silero ONNX 语音活动检测 |
 | KWS | `audio/kws/sherpa.py` | Sherpa ONNX 关键词唤醒（信心度 2.0，阈值 0.2） |
 | ASR | `audio/asr/sherpa.py` | Sherpa SenseVoice 离线语音识别（懒加载，INT8 量化） |
-| TTS | `tts/doubao.py` | 豆包 TTS（流式/一次性，PCM/MP3 自适应） |
+| TTS | `tts/doubao.py`, `tts/mlx_audio.py` | 豆包 TTS 与 MLX-Audio TTS（一次性/本地音频播放） |
 
 ### Rust 原生扩展 (native/)
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 [📺 演示 ①](https://www.bilibili.com/video/BV1DHcBz1Ex7) · [📺 演示 ②](https://www.bilibili.com/video/BV1UQQSBHEvg)
 
-[📖 快速开始](#-快速开始) · [🔌 OpenAI 兼容服务](#-openai-兼容服务) · [🐾 QwenPaw 集成](#-qwenpaw-集成) · [🦞 OpenClaw 集成](#-openclaw-集成) · [🔧 API 文档](#-api-server) · [🐛 常见问题](#-常见问题)
+[📖 快速开始](#-快速开始) · [🔊 TTS 配置](#-tts-配置) · [🔌 OpenAI 兼容服务](#-openai-兼容服务) · [🐾 QwenPaw 集成](#-qwenpaw-集成) · [🦞 OpenClaw 集成](#-openclaw-集成) · [🔧 API 文档](#-api-server) · [🐛 常见问题](#-常见问题)
 
 > 本项目受 [Open-XiaoAI](https://github.com/idootop/open-xiaoai) 启发，并参考其 `examples/xiaozhi/` 示例演进而来，现已作为独立项目持续维护。
 
@@ -344,6 +344,141 @@ curl -X POST http://localhost:9092/api/interrupt
 
 ***
 
+## 🔊 TTS 配置
+
+Bridge 的 TTS provider 配置跟随各个后端，配置层级保持不变：
+
+- `openai.tts_provider`、`openclaw.tts_provider` 和 `qwenpaw.tts_provider` 都可以选择小爱原生、豆包、官方 OpenAI / 兼容服务或本地 MLX-Audio。
+- 各后端继续使用自己的 `tts_speaker`、`session_tts_speakers` 或 `agent_tts_speakers`；不填写 `tts_provider` 时，保持旧逻辑：`xiaoai` 使用小爱原生，其他音色 ID 使用豆包。
+
+### 选择 TTS provider
+
+在对应后端配置中增加 `tts_provider` 即可，原有的 `tts_speaker` 不需要删除：
+
+```python
+"openai": {
+    "tts_provider": "mlx_audio",  # xiaoai / doubao / openai / mlx_audio
+    "tts_speaker": "xiaoai",
+}
+```
+
+同样的字段也可以放在 `openclaw` 和 `qwenpaw` 中：
+
+```python
+"openclaw": {
+    "tts_provider": "doubao",
+    "tts_speaker": "zh_male_raphael_bigtts",
+},
+"qwenpaw": {
+    "tts_provider": "xiaoai",
+    "tts_speaker": "xiaoai",
+}
+```
+
+| `tts_provider` | 运行位置 | 额外配置 |
+|---|---|---|
+| `xiaoai` | 音箱本地原生 TTS | 无，音色由小爱设备决定 |
+| `doubao` | 火山引擎云端 TTS | `tts.doubao`，需要 `app_id` 和 `access_key` |
+| `openai` | 官方 OpenAI 或其他兼容服务 | `tts.openai` |
+| `mlx_audio` | Mac 本地 MLX-Audio 服务 | `tts.mlx_audio` |
+
+### 小爱原生 TTS
+
+不需要启动额外服务，直接使用音箱自带的合成能力：
+
+```python
+"openai": {
+    "tts_provider": "xiaoai",
+    "tts_speaker": "xiaoai",
+}
+```
+
+### 豆包 TTS
+
+先在 [火山引擎语音合成控制台](https://www.volcengine.com/docs/6561/1871062) 开通服务，然后配置鉴权信息和默认音色：
+
+```python
+"tts": {
+    "doubao": {
+        "app_id": "你的 App ID",
+        "access_key": "你的 Access Key",
+        "default_speaker": "zh_female_vv_uranus_bigtts",
+        "audio_format": "pcm",
+        "stream": True,
+    },
+},
+"openai": {
+    "tts_provider": "doubao",
+    # 填豆包音色 ID 可覆盖 default_speaker；填 xiaoai 则使用 default_speaker
+    "tts_speaker": "xiaoai",
+}
+```
+
+音色 ID 见 [火山引擎音色库](https://www.volcengine.com/docs/6561/1257544?lang=zh)。豆包的流式配置和声音复刻说明见下方 [豆包 TTS 常见问题](#-豆包-tts-常见问题)。
+
+### OpenAI / 兼容服务 TTS
+
+适用于官方 OpenAI，以及实现 `POST /v1/audio/speech` 的其他服务。在需要使用它的后端中配置 `tts_provider = "openai"`，然后填写共享的 `tts.openai`：
+
+```python
+"tts": {
+    "openai": {
+        "base_url": "https://api.openai.com/v1",
+        "api_key": "your-api-key",
+        "model": "gpt-4o-mini-tts",
+        "voice": "alloy",
+        "instructions": "自然、放松地说话，不要播音腔。",
+        "response_format": "wav",
+        "speed": 1.0,
+        "timeout": 120,
+        "stream_format": "audio",
+        "extra_body": {},
+    },
+},
+"openai": {
+    "tts_provider": "openai",
+    "tts_speaker": "xiaoai",  # 改成具体 voice ID 可覆盖 tts.openai.voice
+}
+```
+
+适配器发送标准非流式字段：`model`、`input`、`voice`、`instructions`、`response_format` 和 `speed`。当前音箱播放链路支持 `mp3`、`flac`、`wav`、`ogg`、`pcm`；协议层虽然接受 `opus` 和 `aac`，但这两种格式不适合作为 Bridge 的音箱播放格式。当前不支持流式 TTS，设置 `stream_format = "sse"` 或在 `extra_body` 中启用 `stream` 会明确报错。
+
+### MLX-Audio TTS
+
+适用于 Apple Silicon 本地部署的 [MLX-Audio](https://github.com/Blaizzy/mlx-audio) 服务。在需要使用它的后端中配置 `tts_provider = "mlx_audio"`；Bridge 在 Docker 中运行时，通过 `host.docker.internal` 访问 Mac 宿主机：
+
+```python
+"tts": {
+    "mlx_audio": {
+        "base_url": "http://host.docker.internal:8000/v1",
+        "api_key": "",
+        "model": "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-6bit",
+        "mode": "voice_design",  # 或 "custom_voice"
+        "voice": None,             # VoiceDesign 不需要预设音色
+        "lang_code": "Chinese",
+        "response_format": "wav",
+        "speed": 1.0,
+        "instruct": "年轻男性，自然聊天，标准普通话，无明显地域口音。",
+        "timeout": 120,
+        "extra_body": {},
+    },
+},
+"openai": {
+    "tts_provider": "mlx_audio",
+    "tts_speaker": "xiaoai",
+}
+```
+
+`voice_design` 用 `instruct` 描述音色，`custom_voice` 使用模型提供的 `voice`。适配器复用 OpenAI TTS 的 HTTP、鉴权、超时和错误处理，同时把标准 `instructions` 映射为 MLX-Audio 的 `instruct`，并额外支持 `lang_code` 等本地模型参数。协议层支持 `wav`、`mp3`、`flac`、`ogg` 和 `opus`；交给音箱播放时建议使用 `wav`、`mp3`、`flac` 或 `ogg`，不支持 `stream=true`。
+
+### 音频格式与流式限制
+
+- 本地音箱播放优先使用 `wav`；云端服务可根据延迟和带宽选择 `mp3` 或 `pcm`。
+- OpenAI / MLX-Audio 适配器当前采用“完整音频文件 → 音箱播放”，不把 SSE 音频流当作完整文件处理。
+- 豆包 TTS 保留独立的 `stream` 配置，可使用 PCM 或 MP3 流式播放。
+
+***
+
 ## 🔌 OpenAI 兼容服务
 
 用于接入 Hermes Agent API Server、OpenAI、Ollama、LM Studio 等兼容 OpenAI Chat Completions 的服务。它是独立后端，不依赖 OpenClaw 协议。
@@ -363,43 +498,12 @@ curl -X POST http://localhost:9092/api/interrupt
     "temperature": 0.7,
     "max_tokens": 512,
     "history_max_messages": 20,
-    "tts_provider": "mlx_audio",  # 或 "xiaoai"、"doubao"
+    "tts_provider": "mlx_audio",  # 详见「🔊 TTS 配置」
     "tts_speaker": "xiaoai",
 }
 ```
 
-### 🧠 MLX-Audio TTS
-
-可在 Apple Silicon 上本地运行 [MLX-Audio](https://github.com/Blaizzy/mlx-audio)，通过它提供的 OpenAI-compatible `/v1/audio/speech` 接口合成语音。桥接器使用完整音频文件播放，推荐输出 `wav`。
-
-在 `config.py` 中增加配置：
-
-```python
-"tts": {
-    "mlx_audio": {
-        # Docker 中访问宿主机服务；本地运行时可改为 127.0.0.1
-        "base_url": "http://host.docker.internal:8000/v1",
-        "api_key": "",
-        "model": "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-6bit",
-        "mode": "voice_design",  # 或 "custom_voice"
-        "voice": None,             # VoiceDesign 不需要预设音色
-        "lang_code": "Chinese",
-        "response_format": "wav",
-        "speed": 1.0,
-        "instruct": "年轻男性，自然聊天，标准普通话，无明显地域口音。",
-    },
-},
-```
-
-同时设置：
-
-```python
-"openai": {
-    "tts_provider": "mlx_audio",
-}
-```
-
-`voice_design` 使用 `instruct` 描述音色；`custom_voice` 使用 MLX-Audio 模型提供的 `voice`。当前适配器支持 `wav`、`mp3`、`flac`、`ogg` 和 `pcm`，不支持 `stream=true`。
+TTS provider 的选择和音频参数见上方 [🔊 TTS 配置](#-tts-配置)。
 
 触发连续对话时，在 `before_wakeup` 中返回 `"openai"`：
 
@@ -699,12 +803,21 @@ async def after_wakeup(speaker, source=None, session_key=None):
 
 ### 🎵 OpenClaw TTS 音色
 
-`openclaw.tts_speaker` 支持两种值：
+`openclaw.tts_provider` 决定使用哪一种 TTS provider，`openclaw.tts_speaker` 决定音色或 voice。现在可以这样配置：
+
+```python
+"openclaw": {
+    "tts_provider": "mlx_audio",
+    "tts_speaker": "xiaoai",  # 使用 tts.mlx_audio.voice 或 instruct
+}
+```
+
+如果不填写 `tts_provider`，则保持旧行为，`tts_speaker` 支持两种值：
 
 | 值          | 效果       | 说明                                                    |
 | ---------- | -------- | ----------------------------------------------------- |
 | `"xiaoai"` | 小爱原生 TTS | 零配置即可使用，音色由设备决定                                       |
-| 豆包音色 ID    | 豆包语音合成   | 需配置 `tts.doubao` 的 `app_id` 和 `access_key`，详见 [豆包 TTS 章节](#-豆包-tts) |
+| 豆包音色 ID    | 豆包语音合成   | 需配置 `tts.doubao` 的 `app_id` 和 `access_key`，详见 [TTS 配置](#-tts-配置) |
 
 如果希望不同 Agent 使用不同音色，可以配置 `openclaw.agent_tts_speakers`。它会根据当前 `session_key` 中的 `agentId` 选择对应音色；未命中时回退到 `openclaw.tts_speaker`。
 
@@ -1049,24 +1162,11 @@ APP_CONFIG = {
     }
     ```
 
-### 🎵 豆包 TTS
+### 🎵 豆包 TTS 常见问题
 
 1. **如何配置豆包 TTS？**
 
-    1. 开通[火山引擎语音合成服务](https://www.volcengine.com/docs/6561/1871062)，获取 App ID 和 Access Key（[接入文档](https://www.volcengine.com/docs/6561/1598757?lang=zh)）
-    2. 填入配置：
-
-    ```python
-    "tts": {
-        "doubao": {
-            "app_id": "你的 App ID",
-            "access_key": "你的 Access Key",
-            "default_speaker": "zh_female_cancan_mars_bigtts",  # 默认音色，可选列表见下方
-        }
-    }
-    ```
-
-    音色列表：[火山引擎音色库](https://www.volcengine.com/docs/6561/1257544?lang=zh)
+    配置示例、provider 选择和音色说明见上方 [🔊 TTS 配置](#-tts-配置) 的「豆包 TTS」小节。
 
 2. **如何使用声音复刻？**
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ flowchart TB
         subgraph ServicesLayer["服务层（可选）"]
             direction LR
             APIServer["API Server<br/>HTTP :9092"]
-            TTSModule["Doubao TTS"]
+            TTSModule["TTS<br/>Doubao / MLX-Audio"]
         end
     end
 
@@ -363,9 +363,43 @@ curl -X POST http://localhost:9092/api/interrupt
     "temperature": 0.7,
     "max_tokens": 512,
     "history_max_messages": 20,
+    "tts_provider": "mlx_audio",  # 或 "xiaoai"、"doubao"
     "tts_speaker": "xiaoai",
 }
 ```
+
+### 🧠 MLX-Audio TTS
+
+可在 Apple Silicon 上本地运行 [MLX-Audio](https://github.com/Blaizzy/mlx-audio)，通过它提供的 OpenAI-compatible `/v1/audio/speech` 接口合成语音。桥接器使用完整音频文件播放，推荐输出 `wav`。
+
+在 `config.py` 中增加配置：
+
+```python
+"tts": {
+    "mlx_audio": {
+        # Docker 中访问宿主机服务；本地运行时可改为 127.0.0.1
+        "base_url": "http://host.docker.internal:8000/v1",
+        "api_key": "",
+        "model": "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-6bit",
+        "mode": "voice_design",  # 或 "custom_voice"
+        "voice": None,             # VoiceDesign 不需要预设音色
+        "lang_code": "Chinese",
+        "response_format": "wav",
+        "speed": 1.0,
+        "instruct": "年轻男性，自然聊天，标准普通话，无明显地域口音。",
+    },
+},
+```
+
+同时设置：
+
+```python
+"openai": {
+    "tts_provider": "mlx_audio",
+}
+```
+
+`voice_design` 使用 `instruct` 描述音色；`custom_voice` 使用 MLX-Audio 模型提供的 `voice`。当前适配器支持 `wav`、`mp3`、`flac`、`ogg` 和 `pcm`，不支持 `stream=true`。
 
 触发连续对话时，在 `before_wakeup` 中返回 `"openai"`：
 

--- a/core/openai.py
+++ b/core/openai.py
@@ -5,14 +5,10 @@ including Hermes Agent API server mode.
 """
 
 import asyncio
-import os
-import tempfile
 import uuid
 from typing import Any
 
 import aiohttp
-
-import open_xiaoai_server
 
 from core.utils.base import get_env
 from core.utils.config import ConfigManager
@@ -177,15 +173,9 @@ class OpenAIManager:
     @classmethod
     def _resolve_tts_provider(cls, tts_speaker: str | None) -> str:
         """Resolve an explicit provider while preserving the legacy speaker rule."""
-        supported_providers = {"xiaoai", "doubao", "mlx_audio"}
-        if cls._tts_provider:
-            if cls._tts_provider in supported_providers:
-                return cls._tts_provider
-            logger.warning(
-                f"[OpenAI] Unknown tts_provider={cls._tts_provider!r}; "
-                "using legacy speaker-based selection"
-            )
-        return "xiaoai" if tts_speaker == cls.XIAOAI_TTS_SPEAKER else "doubao"
+        from core.services.tts.router import TTSRouter
+
+        return TTSRouter.resolve_provider(cls._tts_provider, tts_speaker)
 
     @classmethod
     async def send(cls, text: str, wait_response: bool = False) -> str | None:
@@ -391,156 +381,32 @@ class OpenAIManager:
         playback_token: int | None = None,
     ):
         """Synthesize text and play it through the speaker."""
-        try:
-            from core.ref import get_speaker
+        from core.services.tts.router import TTSRouter
 
-            resolved_tts_speaker = tts_speaker or cls.get_tts_speaker_for_session_key()
-            provider = cls._resolve_tts_provider(resolved_tts_speaker)
-            if provider == "xiaoai":
-                speaker = get_speaker()
-                if speaker:
-                    await speaker.play(text=text, blocking=True)
-                return
-
-            if provider == "mlx_audio":
-                await cls._play_mlx_audio_tts(
-                    text,
-                    tts_speaker=resolved_tts_speaker,
-                )
-                return
-
-            from core.services.tts.doubao import DoubaoTTS
-
-            tts_config = ConfigManager.instance().get_app_config("tts.doubao", {})
-            app_id = tts_config.get("app_id")
-            access_key = tts_config.get("access_key")
-            if not app_id or not access_key:
-                logger.warning(
-                    "[OpenAI] Doubao TTS credentials not configured, falling back to xiaoai native tts"
-                )
-                speaker = get_speaker()
-                if speaker:
-                    await speaker.play(text=text, blocking=True)
-                return
-
-            speaker_id = resolved_tts_speaker or tts_config.get(
-                "default_speaker", "zh_female_xiaohe_uranus_bigtts"
-            )
-            tts = DoubaoTTS(
-                app_id=app_id,
-                access_key=access_key,
-                speaker=speaker_id,
-            )
-            resolved_format = tts.resolve_audio_format(text)
-            if tts_config.get("stream", False):
-                await open_xiaoai_server.tts_stream_play(
-                    text,
-                    app_id=app_id,
-                    access_key=access_key,
-                    resource_id=tts.resource_id,
-                    speaker=speaker_id,
-                    speed=cls._tts_speed,
-                    format=resolved_format,
-                    sample_rate=24000,
-                    playback_token=playback_token,
-                )
-            else:
-                await open_xiaoai_server.tts_play(
-                    text,
-                    app_id=app_id,
-                    access_key=access_key,
-                    resource_id=tts.resource_id,
-                    speaker=speaker_id,
-                    speed=cls._tts_speed,
-                    format=resolved_format,
-                    sample_rate=24000,
-                    playback_token=playback_token,
-                )
-        except Exception as exc:
-            logger.error(f"[OpenAI] Error playing response with TTS: {exc}")
-            try:
-                from core.ref import get_speaker
-
-                speaker = get_speaker()
-                if speaker:
-                    await speaker.play(text=text, blocking=True)
-            except Exception as fallback_error:
-                logger.error(f"[OpenAI] Fallback TTS also failed: {fallback_error}")
+        resolved_tts_speaker = tts_speaker or cls.get_tts_speaker_for_session_key()
+        await TTSRouter.play(
+            text,
+            configured_provider=cls._tts_provider,
+            tts_speaker=resolved_tts_speaker,
+            tts_speed=cls._tts_speed,
+            playback_token=playback_token,
+            log_prefix="OpenAI",
+        )
 
     @classmethod
-    async def _play_mlx_audio_tts(
+    async def _play_openai_compatible_tts(
         cls,
         text: str,
         tts_speaker: str | None = None,
+        provider: str = "openai",
     ):
-        """Synthesize through MLX-Audio and play the audio file."""
-        from core.ref import get_speaker
-        from core.services.tts.mlx_audio import (
-            MLXAudioTTS,
-            MLXAudioTTSTimeoutError,
-        )
+        """Compatibility wrapper for the shared TTS router."""
+        from core.services.tts.router import TTSRouter
 
-        tts_config = ConfigManager.instance().get_app_config(
-            "tts.mlx_audio", {}
+        await TTSRouter.play(
+            text,
+            configured_provider=provider,
+            tts_speaker=tts_speaker,
+            tts_speed=cls._tts_speed,
+            log_prefix="OpenAI",
         )
-        voice_override = (
-            tts_speaker
-            if tts_speaker and tts_speaker != cls.XIAOAI_TTS_SPEAKER
-            else None
-        )
-        tts = MLXAudioTTS.from_config(
-            tts_config,
-            voice_override=voice_override,
-        )
-        logger.info(
-            "[MLX-Audio TTS] Requesting speech: "
-            f"url={tts.speech_url}, model={tts.model}, voice={tts.voice}, "
-            f"format={tts.response_format}"
-        )
-
-        temporary_path: str | None = None
-        try:
-            audio = await tts.synthesize(text)
-            safe_format = "".join(
-                character for character in tts.response_format.lower() if character.isalnum()
-            ) or "wav"
-            with tempfile.NamedTemporaryFile(
-                prefix="mlx_audio_tts_",
-                suffix=f".{safe_format}",
-                delete=False,
-            ) as audio_file:
-                temporary_path = audio_file.name
-                audio_file.write(audio)
-
-            speaker = get_speaker()
-            if not speaker:
-                raise RuntimeError("Speaker manager is not available")
-            played = await speaker.play_server_file(
-                file_path=temporary_path,
-                blocking=True,
-            )
-            if played is False:
-                raise RuntimeError("SpeakerManager.play_server_file returned false")
-        except MLXAudioTTSTimeoutError:
-            logger.warning(
-                "[MLX-Audio TTS] Request timed out; "
-                "falling back to xiaoai native tts"
-            )
-            raise
-        except Exception as exc:
-            logger.error(
-                "[MLX-Audio TTS] Request or playback failed: "
-                f"{type(exc).__name__}: {exc}; falling back to xiaoai native tts"
-            )
-            raise
-        finally:
-            if temporary_path:
-                try:
-                    os.unlink(temporary_path)
-                except FileNotFoundError:
-                    pass
-                except OSError as exc:
-                    logger.warning(
-                        "[MLX-Audio TTS] Failed to remove temporary "
-                        f"audio file {temporary_path}: {exc}"
-                    )

--- a/core/openai.py
+++ b/core/openai.py
@@ -5,6 +5,8 @@ including Hermes Agent API server mode.
 """
 
 import asyncio
+import os
+import tempfile
 import uuid
 from typing import Any
 
@@ -39,6 +41,7 @@ class OpenAIManager:
     _timeout = 120
     _history_max_messages = 20
     _extra_body: dict[str, Any] = {}
+    _tts_provider: str | None = None
     _tts_speaker = None
     _session_tts_speakers: dict[str, str] = {}
     _tts_speed = 1.0
@@ -91,6 +94,12 @@ class OpenAIManager:
         cls._extra_body = config.get("extra_body", {})
         if not isinstance(cls._extra_body, dict):
             cls._extra_body = {}
+        configured_provider = config.get("tts_provider")
+        cls._tts_provider = (
+            str(configured_provider).strip().lower()
+            if configured_provider
+            else None
+        )
         cls._tts_speaker = config.get("tts_speaker", None)
         cls._session_tts_speakers = (
             {
@@ -164,6 +173,19 @@ class OpenAIManager:
     def get_tts_speaker_for_session_key(cls, session_key: str | None = None) -> str | None:
         target_session_key = session_key or cls._session_key
         return cls._session_tts_speakers.get(target_session_key) or cls._tts_speaker
+
+    @classmethod
+    def _resolve_tts_provider(cls, tts_speaker: str | None) -> str:
+        """Resolve an explicit provider while preserving the legacy speaker rule."""
+        supported_providers = {"xiaoai", "doubao", "mlx_audio"}
+        if cls._tts_provider:
+            if cls._tts_provider in supported_providers:
+                return cls._tts_provider
+            logger.warning(
+                f"[OpenAI] Unknown tts_provider={cls._tts_provider!r}; "
+                "using legacy speaker-based selection"
+            )
+        return "xiaoai" if tts_speaker == cls.XIAOAI_TTS_SPEAKER else "doubao"
 
     @classmethod
     async def send(cls, text: str, wait_response: bool = False) -> str | None:
@@ -373,10 +395,18 @@ class OpenAIManager:
             from core.ref import get_speaker
 
             resolved_tts_speaker = tts_speaker or cls.get_tts_speaker_for_session_key()
-            if resolved_tts_speaker == cls.XIAOAI_TTS_SPEAKER:
+            provider = cls._resolve_tts_provider(resolved_tts_speaker)
+            if provider == "xiaoai":
                 speaker = get_speaker()
                 if speaker:
                     await speaker.play(text=text, blocking=True)
+                return
+
+            if provider == "mlx_audio":
+                await cls._play_mlx_audio_tts(
+                    text,
+                    tts_speaker=resolved_tts_speaker,
+                )
                 return
 
             from core.services.tts.doubao import DoubaoTTS
@@ -436,3 +466,81 @@ class OpenAIManager:
                     await speaker.play(text=text, blocking=True)
             except Exception as fallback_error:
                 logger.error(f"[OpenAI] Fallback TTS also failed: {fallback_error}")
+
+    @classmethod
+    async def _play_mlx_audio_tts(
+        cls,
+        text: str,
+        tts_speaker: str | None = None,
+    ):
+        """Synthesize through MLX-Audio and play the audio file."""
+        from core.ref import get_speaker
+        from core.services.tts.mlx_audio import (
+            MLXAudioTTS,
+            MLXAudioTTSTimeoutError,
+        )
+
+        tts_config = ConfigManager.instance().get_app_config(
+            "tts.mlx_audio", {}
+        )
+        voice_override = (
+            tts_speaker
+            if tts_speaker and tts_speaker != cls.XIAOAI_TTS_SPEAKER
+            else None
+        )
+        tts = MLXAudioTTS.from_config(
+            tts_config,
+            voice_override=voice_override,
+        )
+        logger.info(
+            "[MLX-Audio TTS] Requesting speech: "
+            f"url={tts.speech_url}, model={tts.model}, voice={tts.voice}, "
+            f"format={tts.response_format}"
+        )
+
+        temporary_path: str | None = None
+        try:
+            audio = await tts.synthesize(text)
+            safe_format = "".join(
+                character for character in tts.response_format.lower() if character.isalnum()
+            ) or "wav"
+            with tempfile.NamedTemporaryFile(
+                prefix="mlx_audio_tts_",
+                suffix=f".{safe_format}",
+                delete=False,
+            ) as audio_file:
+                temporary_path = audio_file.name
+                audio_file.write(audio)
+
+            speaker = get_speaker()
+            if not speaker:
+                raise RuntimeError("Speaker manager is not available")
+            played = await speaker.play_server_file(
+                file_path=temporary_path,
+                blocking=True,
+            )
+            if played is False:
+                raise RuntimeError("SpeakerManager.play_server_file returned false")
+        except MLXAudioTTSTimeoutError:
+            logger.warning(
+                "[MLX-Audio TTS] Request timed out; "
+                "falling back to xiaoai native tts"
+            )
+            raise
+        except Exception as exc:
+            logger.error(
+                "[MLX-Audio TTS] Request or playback failed: "
+                f"{type(exc).__name__}: {exc}; falling back to xiaoai native tts"
+            )
+            raise
+        finally:
+            if temporary_path:
+                try:
+                    os.unlink(temporary_path)
+                except FileNotFoundError:
+                    pass
+                except OSError as exc:
+                    logger.warning(
+                        "[MLX-Audio TTS] Failed to remove temporary "
+                        f"audio file {temporary_path}: {exc}"
+                    )

--- a/core/openclaw.py
+++ b/core/openclaw.py
@@ -75,6 +75,7 @@ class OpenClawManager:
     # Config
     XIAOAI_TTS_SPEAKER = "xiaoai"  # Special value: use XiaoAI native TTS instead of Doubao
     _enabled = False
+    _tts_provider: str | None = None
     _tts_speaker = None  # Custom speaker for OpenClaw TTS (uses tts.doubao.default_speaker if not set)
     _agent_tts_speakers: dict[str, str] = {}  # Per-agent speaker overrides
     _tts_speed = 1.0  # TTS speed (0.5-2.0, 1.0 is normal)
@@ -129,6 +130,7 @@ class OpenClawManager:
         cfg_token = config.get("token", "")
         cfg_session = config.get("session_key", "agent:main:open-xiaoai-bridge")
         cfg_identity_path = config.get("identity_path")
+        cfg_tts_provider = config.get("tts_provider")
         cfg_tts_speaker = config.get("tts_speaker", None)
         cfg_agent_tts_speakers = config.get("agent_tts_speakers", {})
         cfg_tts_speed = config.get("tts_speed", 1.0)
@@ -149,6 +151,11 @@ class OpenClawManager:
                 cls._enabled = False  # Default to disabled if no env var set
 
         # TTS config: only from config file
+        cls._tts_provider = (
+            str(cfg_tts_provider).strip().lower()
+            if cfg_tts_provider
+            else None
+        )
         cls._tts_speaker = cfg_tts_speaker
         cls._agent_tts_speakers = (
             {
@@ -961,100 +968,18 @@ class OpenClawManager:
         tts_speaker: str | None = None,
         playback_token: int | None = None,
     ):
-        """Synthesize text using Doubao TTS and play through speaker."""
-        try:
-            from core.ref import get_speaker
+        """Synthesize text using the configured provider and play it."""
+        from core.services.tts.router import TTSRouter
 
-            resolved_tts_speaker = tts_speaker or cls.get_tts_speaker_for_session_key()
-
-            # Special value: use XiaoAI native TTS directly
-            if resolved_tts_speaker == cls.XIAOAI_TTS_SPEAKER:
-                logger.info(
-                    f"[OpenClaw] Using OpenClaw TTS speaker: session_key={cls._session_key}, "
-                    f"speaker={resolved_tts_speaker}"
-                )
-                speaker = get_speaker()
-                if speaker:
-                    await speaker.play(text=text, blocking=True)
-                return
-
-            from core.services.tts.doubao import DoubaoTTS
-
-            # Get TTS config
-            tts_config = ConfigManager.instance().get_app_config("tts.doubao", {})
-            app_id = tts_config.get("app_id")
-            access_key = tts_config.get("access_key")
-
-            if not app_id or not access_key:
-                logger.warning("[OpenClaw] Doubao TTS credentials not configured, falling back to xiaoai native tts")
-                speaker = get_speaker()
-                if speaker:
-                    await speaker.play(text=text, blocking=True)
-                return
-
-            speaker_id = resolved_tts_speaker or tts_config.get(
-                "default_speaker", "zh_female_xiaohe_uranus_bigtts"
-            )
-            logger.info(
-                f"[OpenClaw] Using OpenClaw TTS speaker: session_key={cls._session_key}, "
-                f"speaker={speaker_id}, speed={cls._tts_speed}"
-            )
-
-            tts = DoubaoTTS(
-                app_id=app_id,
-                access_key=access_key,
-                speaker=speaker_id,
-            )
-            resolved_format = tts.resolve_audio_format(text)
-
-            use_stream = tts_config.get("stream", False)
-            speaker = get_speaker()
-            if not speaker:
-                logger.error("[OpenClaw] Speaker not available")
-                return
-
-            if use_stream:
-                import open_xiaoai_server
-                try:
-                    await open_xiaoai_server.tts_stream_play(
-                        text,
-                        app_id=app_id,
-                        access_key=access_key,
-                        resource_id=tts.resource_id,
-                        speaker=speaker_id,
-                        speed=cls._tts_speed,
-                        format=resolved_format,
-                        sample_rate=24000,
-                        playback_token=playback_token,
-                    )
-                    logger.debug("[OpenClaw] TTS stream playback completed")
-                except Exception:
-                    raise
-            else:
-                import open_xiaoai_server
-
-                await open_xiaoai_server.tts_play(
-                    text,
-                    app_id=app_id,
-                    access_key=access_key,
-                    resource_id=tts.resource_id,
-                    speaker=speaker_id,
-                    speed=cls._tts_speed,
-                    format=resolved_format,
-                    sample_rate=24000,
-                    playback_token=playback_token,
-                )
-                logger.debug("[OpenClaw] Response playback completed")
-
-        except Exception as e:
-            logger.error(f"[OpenClaw] Error playing response with TTS: {e}")
-            try:
-                from core.ref import get_speaker
-                speaker = get_speaker()
-                if speaker:
-                    await speaker.play(text=text, blocking=True)
-            except Exception as fallback_error:
-                logger.error(f"[OpenClaw] Fallback TTS also failed: {fallback_error}")
+        resolved_tts_speaker = tts_speaker or cls.get_tts_speaker_for_session_key()
+        await TTSRouter.play(
+            text,
+            configured_provider=cls._tts_provider,
+            tts_speaker=resolved_tts_speaker,
+            tts_speed=cls._tts_speed,
+            playback_token=playback_token,
+            log_prefix="OpenClaw",
+        )
 
 
 # No auto-initialization - call OpenClawManager.initialize_from_config() explicitly

--- a/core/qwenpaw.py
+++ b/core/qwenpaw.py
@@ -11,8 +11,6 @@ from typing import Any
 
 import aiohttp
 
-import open_xiaoai_server
-
 from core.utils.base import get_env
 from core.utils.config import ConfigManager
 from core.utils.logger import logger
@@ -34,6 +32,7 @@ class QwenPawManager:
     _task_status_path = "/api/console/chat/task/{task_id}"
     _response_timeout = 120
     _poll_interval = 0.5
+    _tts_provider: str | None = None
     _tts_speaker = None
     _session_tts_speakers: dict[str, str] = {}
     _tts_speed = 1.0
@@ -86,6 +85,12 @@ class QwenPawManager:
         )
         cls._response_timeout = int(config.get("response_timeout", 120))
         cls._poll_interval = max(0.1, float(config.get("poll_interval", 0.5)))
+        configured_provider = config.get("tts_provider")
+        cls._tts_provider = (
+            str(configured_provider).strip().lower()
+            if configured_provider
+            else None
+        )
         cls._tts_speaker = config.get("tts_speaker", None)
         cls._session_tts_speakers = (
             {
@@ -386,71 +391,15 @@ class QwenPawManager:
         tts_speaker: str | None = None,
         playback_token: int | None = None,
     ):
-        """Synthesize text and play it through the speaker."""
-        try:
-            from core.ref import get_speaker
+        """Synthesize text using the configured provider and play it."""
+        from core.services.tts.router import TTSRouter
 
-            resolved_tts_speaker = tts_speaker or cls.get_tts_speaker_for_session_key()
-            if resolved_tts_speaker == cls.XIAOAI_TTS_SPEAKER:
-                speaker = get_speaker()
-                if speaker:
-                    await speaker.play(text=text, blocking=True)
-                return
-
-            from core.services.tts.doubao import DoubaoTTS
-
-            tts_config = ConfigManager.instance().get_app_config("tts.doubao", {})
-            app_id = tts_config.get("app_id")
-            access_key = tts_config.get("access_key")
-            if not app_id or not access_key:
-                logger.warning(
-                    "[QwenPaw] Doubao TTS credentials not configured, falling back to xiaoai native tts"
-                )
-                speaker = get_speaker()
-                if speaker:
-                    await speaker.play(text=text, blocking=True)
-                return
-
-            speaker_id = resolved_tts_speaker or tts_config.get(
-                "default_speaker", "zh_female_xiaohe_uranus_bigtts"
-            )
-            tts = DoubaoTTS(
-                app_id=app_id,
-                access_key=access_key,
-                speaker=speaker_id,
-            )
-            resolved_format = tts.resolve_audio_format(text)
-            if tts_config.get("stream", False):
-                await open_xiaoai_server.tts_stream_play(
-                    text,
-                    app_id=app_id,
-                    access_key=access_key,
-                    resource_id=tts.resource_id,
-                    speaker=speaker_id,
-                    speed=cls._tts_speed,
-                    format=resolved_format,
-                    sample_rate=24000,
-                    playback_token=playback_token,
-                )
-            else:
-                await open_xiaoai_server.tts_play(
-                    text,
-                    app_id=app_id,
-                    access_key=access_key,
-                    resource_id=tts.resource_id,
-                    speaker=speaker_id,
-                    speed=cls._tts_speed,
-                    format=resolved_format,
-                    sample_rate=24000,
-                    playback_token=playback_token,
-                )
-        except Exception as exc:
-            logger.error(f"[QwenPaw] Error playing response with TTS: {exc}")
-            try:
-                from core.ref import get_speaker
-
-                speaker = get_speaker()
-                if speaker:
-                    await speaker.play(text=text, blocking=True)
-            except Exception as fallback_error:
-                logger.error(f"[QwenPaw] Fallback TTS also failed: {fallback_error}")
+        resolved_tts_speaker = tts_speaker or cls.get_tts_speaker_for_session_key()
+        await TTSRouter.play(
+            text,
+            configured_provider=cls._tts_provider,
+            tts_speaker=resolved_tts_speaker,
+            tts_speed=cls._tts_speed,
+            playback_token=playback_token,
+            log_prefix="QwenPaw",
+        )

--- a/core/services/tts/__init__.py
+++ b/core/services/tts/__init__.py
@@ -4,5 +4,6 @@ Supports multiple TTS providers
 """
 
 from .doubao import DoubaoTTS
+from .mlx_audio import MLXAudioTTS
 
-__all__ = ["DoubaoTTS"]
+__all__ = ["DoubaoTTS", "MLXAudioTTS"]

--- a/core/services/tts/__init__.py
+++ b/core/services/tts/__init__.py
@@ -5,5 +5,6 @@ Supports multiple TTS providers
 
 from .doubao import DoubaoTTS
 from .mlx_audio import MLXAudioTTS
+from .openai import OpenAITTS
 
-__all__ = ["DoubaoTTS", "MLXAudioTTS"]
+__all__ = ["DoubaoTTS", "MLXAudioTTS", "OpenAITTS"]

--- a/core/services/tts/mlx_audio.py
+++ b/core/services/tts/mlx_audio.py
@@ -1,0 +1,167 @@
+"""MLX-Audio TTS client for its OpenAI-compatible speech endpoint."""
+
+import asyncio
+from collections.abc import Mapping
+from typing import Any
+
+import aiohttp
+
+
+class MLXAudioTTSError(RuntimeError):
+    """The MLX-Audio TTS server rejected or returned an invalid response."""
+
+
+class MLXAudioTTSTimeoutError(MLXAudioTTSError):
+    """The MLX-Audio TTS request exceeded its configured timeout."""
+
+
+class MLXAudioTTS:
+    """Call MLX-Audio's ``POST /v1/audio/speech`` endpoint."""
+
+    DEFAULT_BASE_URL = "http://127.0.0.1:8000/v1"
+    DEFAULT_MODEL = "Qwen3-TTS"
+    DEFAULT_MODE = "custom_voice"
+    DEFAULT_RESPONSE_FORMAT = "wav"
+    DEFAULT_TIMEOUT = 120.0
+    SUPPORTED_MODES = frozenset(("custom_voice", "voice_design"))
+    SUPPORTED_RESPONSE_FORMATS = frozenset(
+        ("wav", "mp3", "flac", "ogg", "pcm")
+    )
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        api_key: str = "",
+        model: str = DEFAULT_MODEL,
+        mode: str = DEFAULT_MODE,
+        voice: str | None = None,
+        lang_code: str | None = None,
+        response_format: str = DEFAULT_RESPONSE_FORMAT,
+        speed: float | None = 1.0,
+        instruct: str | None = None,
+        timeout: float = DEFAULT_TIMEOUT,
+        extra_body: Mapping[str, Any] | None = None,
+    ):
+        self.base_url = str(base_url or self.DEFAULT_BASE_URL).rstrip("/")
+        self.api_key = str(api_key or "")
+        self.model = str(model or self.DEFAULT_MODEL)
+        self.mode = str(mode or self.DEFAULT_MODE).strip().lower()
+        if self.mode not in self.SUPPORTED_MODES:
+            supported_modes = ", ".join(sorted(self.SUPPORTED_MODES))
+            raise ValueError(f"mode must be one of: {supported_modes}")
+        self.voice = str(voice).strip() if voice else None
+        if self.mode == "voice_design":
+            self.voice = None
+        self.lang_code = str(lang_code).strip() if lang_code else None
+        self.response_format = str(
+            response_format or self.DEFAULT_RESPONSE_FORMAT
+        ).strip().lower()
+        if self.response_format not in self.SUPPORTED_RESPONSE_FORMATS:
+            supported_formats = ", ".join(sorted(self.SUPPORTED_RESPONSE_FORMATS))
+            raise ValueError(f"response_format must be one of: {supported_formats}")
+        self.speed = float(speed) if speed is not None and speed != "" else None
+        self.instruct = str(instruct) if instruct else None
+        self.timeout = float(timeout)
+        self.extra_body = dict(extra_body) if isinstance(extra_body, Mapping) else {}
+        if self.extra_body.get("stream"):
+            raise ValueError("MLXAudioTTS.synthesize does not support stream=true")
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Mapping[str, Any] | None = None,
+        voice_override: str | None = None,
+    ) -> "MLXAudioTTS":
+        """Build the adapter from ``tts.mlx_audio`` settings."""
+        config = config if isinstance(config, Mapping) else {}
+        mode = config.get("mode", cls.DEFAULT_MODE)
+        configured_voice = config.get("voice")
+        voice = voice_override or configured_voice
+        return cls(
+            base_url=config.get("base_url", cls.DEFAULT_BASE_URL),
+            api_key=config.get("api_key", ""),
+            model=config.get("model", cls.DEFAULT_MODEL),
+            mode=mode,
+            voice=voice,
+            lang_code=config.get("lang_code"),
+            response_format=config.get(
+                "response_format", cls.DEFAULT_RESPONSE_FORMAT
+            ),
+            speed=config.get("speed", 1.0),
+            instruct=config.get("instruct"),
+            timeout=config.get("timeout", cls.DEFAULT_TIMEOUT),
+            extra_body=config.get("extra_body"),
+        )
+
+    @property
+    def speech_url(self) -> str:
+        """Return the configured base URL with the speech path appended once."""
+        if self.base_url.endswith("/audio/speech"):
+            return self.base_url
+        return f"{self.base_url}/audio/speech"
+
+    def _payload(self, text: str) -> dict[str, Any]:
+        if not isinstance(text, str) or not text.strip():
+            raise ValueError("text must be a non-empty string")
+
+        payload: dict[str, Any] = dict(self.extra_body)
+        payload.update(
+            {
+                "model": self.model,
+                "input": text,
+                "response_format": self.response_format,
+            }
+        )
+        if self.voice is not None:
+            payload["voice"] = self.voice
+        if self.lang_code is not None:
+            payload["lang_code"] = self.lang_code
+        if self.speed is not None:
+            payload["speed"] = self.speed
+        if self.instruct is not None:
+            payload["instruct"] = self.instruct
+        return payload
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    async def synthesize(self, text: str) -> bytes:
+        """Synthesize ``text`` and return the encoded audio response."""
+        try:
+            timeout = aiohttp.ClientTimeout(total=self.timeout)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(
+                    self.speech_url,
+                    json=self._payload(text),
+                    headers=self._headers(),
+                ) as response:
+                    audio = await response.read()
+                    if response.status < 200 or response.status >= 300:
+                        detail = audio[:500].decode("utf-8", errors="replace")
+                        raise MLXAudioTTSError(
+                            f"HTTP {response.status}: {detail or 'empty error response'}"
+                        )
+                    if not audio:
+                        raise MLXAudioTTSError(
+                            f"HTTP {response.status}: empty audio response"
+                        )
+                    content_type = getattr(response, "content_type", None)
+                    if content_type and not (
+                        content_type.startswith("audio/")
+                        or content_type
+                        in {"application/octet-stream", "binary/octet-stream"}
+                    ):
+                        raise MLXAudioTTSError(
+                            f"HTTP {response.status}: unexpected content type "
+                            f"{content_type}"
+                        )
+                    return audio
+        except asyncio.TimeoutError as exc:
+            raise MLXAudioTTSTimeoutError(
+                f"request timed out after {self.timeout:g}s"
+            ) from exc
+        except aiohttp.ClientError as exc:
+            raise MLXAudioTTSError(f"request failed: {exc}") from exc

--- a/core/services/tts/mlx_audio.py
+++ b/core/services/tts/mlx_audio.py
@@ -1,31 +1,39 @@
-"""MLX-Audio TTS client for its OpenAI-compatible speech endpoint."""
+"""MLX-Audio TTS provider built on the shared OpenAI speech client."""
 
-import asyncio
 from collections.abc import Mapping
 from typing import Any
 
-import aiohttp
+from .openai import (
+    OpenAITTS,
+    OpenAITTSError,
+    OpenAITTSTimeoutError,
+)
 
 
-class MLXAudioTTSError(RuntimeError):
-    """The MLX-Audio TTS server rejected or returned an invalid response."""
+# Keep the old exception names as compatibility aliases for callers that
+# imported them from the MLX provider module.
+MLXAudioTTSError = OpenAITTSError
+MLXAudioTTSTimeoutError = OpenAITTSTimeoutError
 
 
-class MLXAudioTTSTimeoutError(MLXAudioTTSError):
-    """The MLX-Audio TTS request exceeded its configured timeout."""
+class MLXAudioTTS(OpenAITTS):
+    """Call MLX-Audio's OpenAI-compatible speech endpoint.
 
-
-class MLXAudioTTS:
-    """Call MLX-Audio's ``POST /v1/audio/speech`` endpoint."""
+    The HTTP transport and standard fields come from ``OpenAITTS``.  MLX
+    extends the request with local-model controls such as ``lang_code`` and
+    ``instruct``; its ``instruct`` field is the provider-specific equivalent
+    of OpenAI's standard ``instructions`` field.
+    """
 
     DEFAULT_BASE_URL = "http://127.0.0.1:8000/v1"
     DEFAULT_MODEL = "Qwen3-TTS"
     DEFAULT_MODE = "custom_voice"
     DEFAULT_RESPONSE_FORMAT = "wav"
     DEFAULT_TIMEOUT = 120.0
+    REQUIRES_VOICE = False
     SUPPORTED_MODES = frozenset(("custom_voice", "voice_design"))
     SUPPORTED_RESPONSE_FORMATS = frozenset(
-        ("wav", "mp3", "flac", "ogg", "pcm")
+        ("mp3", "wav", "flac", "ogg", "opus")
     )
 
     def __init__(
@@ -39,32 +47,34 @@ class MLXAudioTTS:
         response_format: str = DEFAULT_RESPONSE_FORMAT,
         speed: float | None = 1.0,
         instruct: str | None = None,
+        instructions: str | None = None,
         timeout: float = DEFAULT_TIMEOUT,
         extra_body: Mapping[str, Any] | None = None,
+        stream_format: str = "audio",
     ):
-        self.base_url = str(base_url or self.DEFAULT_BASE_URL).rstrip("/")
-        self.api_key = str(api_key or "")
-        self.model = str(model or self.DEFAULT_MODEL)
         self.mode = str(mode or self.DEFAULT_MODE).strip().lower()
         if self.mode not in self.SUPPORTED_MODES:
             supported_modes = ", ".join(sorted(self.SUPPORTED_MODES))
             raise ValueError(f"mode must be one of: {supported_modes}")
-        self.voice = str(voice).strip() if voice else None
-        if self.mode == "voice_design":
-            self.voice = None
+
         self.lang_code = str(lang_code).strip() if lang_code else None
-        self.response_format = str(
-            response_format or self.DEFAULT_RESPONSE_FORMAT
-        ).strip().lower()
-        if self.response_format not in self.SUPPORTED_RESPONSE_FORMATS:
-            supported_formats = ", ".join(sorted(self.SUPPORTED_RESPONSE_FORMATS))
-            raise ValueError(f"response_format must be one of: {supported_formats}")
-        self.speed = float(speed) if speed is not None and speed != "" else None
-        self.instruct = str(instruct) if instruct else None
-        self.timeout = float(timeout)
-        self.extra_body = dict(extra_body) if isinstance(extra_body, Mapping) else {}
-        if self.extra_body.get("stream"):
-            raise ValueError("MLXAudioTTS.synthesize does not support stream=true")
+        selected_instruct = instruct or instructions
+        self.instruct = str(selected_instruct) if selected_instruct else None
+        if self.mode == "voice_design":
+            voice = None
+
+        super().__init__(
+            base_url=base_url,
+            api_key=api_key,
+            model=model,
+            voice=voice,
+            instructions=None,
+            response_format=response_format,
+            speed=speed,
+            timeout=timeout,
+            extra_body=extra_body,
+            stream_format=stream_format,
+        )
 
     @classmethod
     def from_config(
@@ -89,16 +99,11 @@ class MLXAudioTTS:
             ),
             speed=config.get("speed", 1.0),
             instruct=config.get("instruct"),
+            instructions=config.get("instructions"),
             timeout=config.get("timeout", cls.DEFAULT_TIMEOUT),
             extra_body=config.get("extra_body"),
+            stream_format=config.get("stream_format", "audio"),
         )
-
-    @property
-    def speech_url(self) -> str:
-        """Return the configured base URL with the speech path appended once."""
-        if self.base_url.endswith("/audio/speech"):
-            return self.base_url
-        return f"{self.base_url}/audio/speech"
 
     def _payload(self, text: str) -> dict[str, Any]:
         if not isinstance(text, str) or not text.strip():
@@ -121,47 +126,3 @@ class MLXAudioTTS:
         if self.instruct is not None:
             payload["instruct"] = self.instruct
         return payload
-
-    def _headers(self) -> dict[str, str]:
-        headers = {"Content-Type": "application/json"}
-        if self.api_key:
-            headers["Authorization"] = f"Bearer {self.api_key}"
-        return headers
-
-    async def synthesize(self, text: str) -> bytes:
-        """Synthesize ``text`` and return the encoded audio response."""
-        try:
-            timeout = aiohttp.ClientTimeout(total=self.timeout)
-            async with aiohttp.ClientSession(timeout=timeout) as session:
-                async with session.post(
-                    self.speech_url,
-                    json=self._payload(text),
-                    headers=self._headers(),
-                ) as response:
-                    audio = await response.read()
-                    if response.status < 200 or response.status >= 300:
-                        detail = audio[:500].decode("utf-8", errors="replace")
-                        raise MLXAudioTTSError(
-                            f"HTTP {response.status}: {detail or 'empty error response'}"
-                        )
-                    if not audio:
-                        raise MLXAudioTTSError(
-                            f"HTTP {response.status}: empty audio response"
-                        )
-                    content_type = getattr(response, "content_type", None)
-                    if content_type and not (
-                        content_type.startswith("audio/")
-                        or content_type
-                        in {"application/octet-stream", "binary/octet-stream"}
-                    ):
-                        raise MLXAudioTTSError(
-                            f"HTTP {response.status}: unexpected content type "
-                            f"{content_type}"
-                        )
-                    return audio
-        except asyncio.TimeoutError as exc:
-            raise MLXAudioTTSTimeoutError(
-                f"request timed out after {self.timeout:g}s"
-            ) from exc
-        except aiohttp.ClientError as exc:
-            raise MLXAudioTTSError(f"request failed: {exc}") from exc

--- a/core/services/tts/openai.py
+++ b/core/services/tts/openai.py
@@ -1,0 +1,205 @@
+"""OpenAI-compatible text-to-speech client."""
+
+import asyncio
+from collections.abc import Mapping
+from typing import Any
+
+import aiohttp
+
+
+PLAYBACK_SUPPORTED_FORMATS = frozenset(("mp3", "flac", "wav", "ogg", "pcm"))
+
+
+class OpenAITTSError(RuntimeError):
+    """The TTS server rejected or returned an invalid response."""
+
+
+class OpenAITTSTimeoutError(OpenAITTSError):
+    """The TTS request exceeded its configured timeout."""
+
+
+class OpenAITTS:
+    """Call a non-streaming OpenAI-compatible ``/v1/audio/speech`` endpoint.
+
+    The client intentionally implements the portable, non-streaming part of
+    the OpenAI speech API.  Provider-specific extensions belong in a thin
+    subclass (for example :class:`MLXAudioTTS`).
+    """
+
+    DEFAULT_BASE_URL = "https://api.openai.com/v1"
+    DEFAULT_MODEL = "gpt-4o-mini-tts"
+    DEFAULT_VOICE = "alloy"
+    DEFAULT_RESPONSE_FORMAT = "mp3"
+    DEFAULT_SPEED = 1.0
+    DEFAULT_TIMEOUT = 120.0
+    REQUIRES_VOICE = True
+    SUPPORTED_RESPONSE_FORMATS = frozenset(
+        ("mp3", "opus", "aac", "flac", "wav", "pcm")
+    )
+    SUPPORTED_STREAM_FORMATS = frozenset(("audio", "sse"))
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        api_key: str = "",
+        model: str = DEFAULT_MODEL,
+        voice: str | Mapping[str, Any] | None = DEFAULT_VOICE,
+        instructions: str | None = None,
+        response_format: str = DEFAULT_RESPONSE_FORMAT,
+        speed: float | None = DEFAULT_SPEED,
+        timeout: float = DEFAULT_TIMEOUT,
+        extra_body: Mapping[str, Any] | None = None,
+        stream_format: str = "audio",
+    ):
+        self.base_url = str(base_url or self.DEFAULT_BASE_URL).rstrip("/")
+        self.api_key = str(api_key or "")
+        self.model = str(model or self.DEFAULT_MODEL)
+        self.voice = self._normalize_voice(voice)
+        if self.REQUIRES_VOICE and self.voice is None:
+            raise ValueError("voice is required for the OpenAI TTS provider")
+        self.instructions = str(instructions) if instructions else None
+        self.response_format = str(
+            response_format or self.DEFAULT_RESPONSE_FORMAT
+        ).strip().lower()
+        if self.response_format not in self.SUPPORTED_RESPONSE_FORMATS:
+            supported_formats = ", ".join(sorted(self.SUPPORTED_RESPONSE_FORMATS))
+            raise ValueError(
+                f"response_format must be one of: {supported_formats}"
+            )
+
+        self.speed = float(speed) if speed is not None and speed != "" else None
+        if self.speed is not None and not 0.25 <= self.speed <= 4.0:
+            raise ValueError("speed must be between 0.25 and 4.0")
+
+        self.timeout = float(timeout)
+        self.extra_body = (
+            dict(extra_body) if isinstance(extra_body, Mapping) else {}
+        )
+        extra_stream_format = self.extra_body.get("stream_format")
+        if extra_stream_format and str(extra_stream_format).lower() != "audio":
+            raise ValueError(
+                "stream_format='sse' is not supported by the file playback path"
+            )
+        self.stream_format = str(stream_format or "audio").strip().lower()
+        if self.stream_format not in self.SUPPORTED_STREAM_FORMATS:
+            supported_stream_formats = ", ".join(
+                sorted(self.SUPPORTED_STREAM_FORMATS)
+            )
+            raise ValueError(
+                "stream_format must be one of: "
+                f"{supported_stream_formats}"
+            )
+        if self.stream_format != "audio":
+            raise ValueError(
+                "stream_format='sse' is not supported by the file playback path"
+            )
+        if self.extra_body.get("stream"):
+            raise ValueError("OpenAITTS.synthesize does not support stream=true")
+
+    @staticmethod
+    def _normalize_voice(
+        voice: str | Mapping[str, Any] | None,
+    ) -> str | dict[str, Any] | None:
+        if isinstance(voice, Mapping):
+            normalized = dict(voice)
+            if not normalized.get("id"):
+                raise ValueError("voice object must include an id")
+            return normalized
+        return str(voice).strip() if voice else None
+
+    @classmethod
+    def from_config(
+        cls,
+        config: Mapping[str, Any] | None = None,
+        voice_override: str | Mapping[str, Any] | None = None,
+    ) -> "OpenAITTS":
+        """Build the client from a ``tts.openai`` configuration mapping."""
+        config = config if isinstance(config, Mapping) else {}
+        configured_voice = config.get("voice", cls.DEFAULT_VOICE)
+        voice = voice_override if voice_override is not None else configured_voice
+        return cls(
+            base_url=config.get("base_url", cls.DEFAULT_BASE_URL),
+            api_key=config.get("api_key", ""),
+            model=config.get("model", cls.DEFAULT_MODEL),
+            voice=voice,
+            instructions=config.get("instructions"),
+            response_format=config.get(
+                "response_format", cls.DEFAULT_RESPONSE_FORMAT
+            ),
+            speed=config.get("speed", cls.DEFAULT_SPEED),
+            timeout=config.get("timeout", cls.DEFAULT_TIMEOUT),
+            extra_body=config.get("extra_body"),
+            stream_format=config.get("stream_format", "audio"),
+        )
+
+    @property
+    def speech_url(self) -> str:
+        """Return the configured base URL with the speech path appended once."""
+        if self.base_url.endswith("/audio/speech"):
+            return self.base_url
+        return f"{self.base_url}/audio/speech"
+
+    def _payload(self, text: str) -> dict[str, Any]:
+        if not isinstance(text, str) or not text.strip():
+            raise ValueError("text must be a non-empty string")
+
+        payload: dict[str, Any] = dict(self.extra_body)
+        payload.update(
+            {
+                "model": self.model,
+                "input": text,
+                "response_format": self.response_format,
+            }
+        )
+        if self.voice is not None:
+            payload["voice"] = self.voice
+        if self.instructions is not None:
+            payload["instructions"] = self.instructions
+        if self.speed is not None:
+            payload["speed"] = self.speed
+        return payload
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+        return headers
+
+    async def synthesize(self, text: str) -> bytes:
+        """Synthesize ``text`` and return the encoded audio response."""
+        try:
+            timeout = aiohttp.ClientTimeout(total=self.timeout)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.post(
+                    self.speech_url,
+                    json=self._payload(text),
+                    headers=self._headers(),
+                ) as response:
+                    audio = await response.read()
+                    if response.status < 200 or response.status >= 300:
+                        detail = audio[:500].decode("utf-8", errors="replace")
+                        raise OpenAITTSError(
+                            f"HTTP {response.status}: "
+                            f"{detail or 'empty error response'}"
+                        )
+                    if not audio:
+                        raise OpenAITTSError(
+                            f"HTTP {response.status}: empty audio response"
+                        )
+                    content_type = getattr(response, "content_type", None)
+                    if content_type and not (
+                        content_type.startswith("audio/")
+                        or content_type
+                        in {"application/octet-stream", "binary/octet-stream"}
+                    ):
+                        raise OpenAITTSError(
+                            f"HTTP {response.status}: unexpected content type "
+                            f"{content_type}"
+                        )
+                    return audio
+        except asyncio.TimeoutError as exc:
+            raise OpenAITTSTimeoutError(
+                f"request timed out after {self.timeout:g}s"
+            ) from exc
+        except aiohttp.ClientError as exc:
+            raise OpenAITTSError(f"request failed: {exc}") from exc

--- a/core/services/tts/router.py
+++ b/core/services/tts/router.py
@@ -1,0 +1,218 @@
+"""Shared TTS provider routing and playback for all conversation backends."""
+
+import os
+import tempfile
+
+import open_xiaoai_server
+
+from core.services.tts.doubao import DoubaoTTS
+from core.services.tts.mlx_audio import MLXAudioTTS
+from core.services.tts.openai import PLAYBACK_SUPPORTED_FORMATS, OpenAITTS
+from core.utils.config import ConfigManager
+from core.utils.logger import logger
+
+
+class TTSRouter:
+    """Resolve a backend's TTS settings and play the generated response."""
+
+    XIAOAI_TTS_SPEAKER = "xiaoai"
+    SUPPORTED_PROVIDERS = frozenset(("xiaoai", "doubao", "openai", "mlx_audio"))
+
+    @classmethod
+    def resolve_provider(
+        cls,
+        configured_provider: str | None,
+        tts_speaker: str | None,
+    ) -> str:
+        """Resolve an explicit provider while preserving legacy selection."""
+        provider = str(configured_provider or "").strip().lower()
+        if provider in cls.SUPPORTED_PROVIDERS:
+            return provider
+        if provider:
+            logger.warning(
+                f"Unknown tts_provider={configured_provider!r}; "
+                "using legacy speaker-based selection"
+            )
+        return "xiaoai" if tts_speaker == cls.XIAOAI_TTS_SPEAKER else "doubao"
+
+    @classmethod
+    async def play(
+        cls,
+        text: str,
+        *,
+        configured_provider: str | None,
+        tts_speaker: str | None,
+        tts_speed: float = 1.0,
+        playback_token: int | None = None,
+        log_prefix: str = "TTS",
+    ) -> None:
+        """Synthesize and play text, falling back to XiaoAI native TTS."""
+        provider = cls.resolve_provider(configured_provider, tts_speaker)
+        try:
+            if provider == "xiaoai":
+                from core.ref import get_speaker
+
+                speaker = get_speaker()
+                if speaker:
+                    await speaker.play(text=text, blocking=True)
+                return
+
+            if provider == "doubao":
+                await cls._play_doubao(
+                    text,
+                    tts_speaker=tts_speaker,
+                    tts_speed=tts_speed,
+                    playback_token=playback_token,
+                )
+                return
+
+            await cls._play_openai_compatible(
+                text,
+                provider=provider,
+                tts_speaker=tts_speaker,
+            )
+        except Exception as exc:
+            logger.error(
+                f"[{log_prefix}] Error playing response with TTS: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            await cls._fallback_to_xiaoai(text, log_prefix=log_prefix)
+
+    @classmethod
+    async def _play_doubao(
+        cls,
+        text: str,
+        *,
+        tts_speaker: str | None,
+        tts_speed: float,
+        playback_token: int | None,
+    ) -> None:
+        tts_config = ConfigManager.instance().get_app_config("tts.doubao", {})
+        app_id = tts_config.get("app_id")
+        access_key = tts_config.get("access_key")
+        if not app_id or not access_key:
+            raise ValueError("Doubao TTS credentials are not configured")
+
+        speaker_id = (
+            tts_speaker
+            if tts_speaker and tts_speaker != cls.XIAOAI_TTS_SPEAKER
+            else tts_config.get("default_speaker", "zh_female_xiaohe_uranus_bigtts")
+        )
+        tts = DoubaoTTS(
+            app_id=app_id,
+            access_key=access_key,
+            speaker=speaker_id,
+        )
+        resolved_format = tts.resolve_audio_format(text)
+        if tts_config.get("stream", False):
+            await open_xiaoai_server.tts_stream_play(
+                text,
+                app_id=app_id,
+                access_key=access_key,
+                resource_id=tts.resource_id,
+                speaker=speaker_id,
+                speed=tts_speed,
+                format=resolved_format,
+                sample_rate=24000,
+                playback_token=playback_token,
+            )
+        else:
+            await open_xiaoai_server.tts_play(
+                text,
+                app_id=app_id,
+                access_key=access_key,
+                resource_id=tts.resource_id,
+                speaker=speaker_id,
+                speed=tts_speed,
+                format=resolved_format,
+                sample_rate=24000,
+                playback_token=playback_token,
+            )
+
+    @classmethod
+    async def _play_openai_compatible(
+        cls,
+        text: str,
+        *,
+        provider: str,
+        tts_speaker: str | None,
+    ) -> None:
+        if provider == "mlx_audio":
+            tts_class = MLXAudioTTS
+            config_key = "tts.mlx_audio"
+            log_name = "MLX-Audio"
+            file_prefix = "mlx_audio_tts_"
+        else:
+            tts_class = OpenAITTS
+            config_key = "tts.openai"
+            log_name = "OpenAI"
+            file_prefix = "openai_tts_"
+
+        tts_config = ConfigManager.instance().get_app_config(config_key, {})
+        voice_override = (
+            tts_speaker
+            if tts_speaker and tts_speaker != cls.XIAOAI_TTS_SPEAKER
+            else None
+        )
+        tts = tts_class.from_config(tts_config, voice_override=voice_override)
+        logger.info(
+            f"[{log_name} TTS] Requesting speech: "
+            f"url={tts.speech_url}, model={tts.model}, voice={tts.voice}, "
+            f"format={tts.response_format}"
+        )
+
+        if tts.response_format not in PLAYBACK_SUPPORTED_FORMATS:
+            raise ValueError(
+                f"response_format={tts.response_format!r} is not supported by "
+                "the Bridge playback decoder; use mp3, flac, wav, ogg, or pcm"
+            )
+
+        temporary_path: str | None = None
+        try:
+            audio = await tts.synthesize(text)
+            safe_format = "".join(
+                character
+                for character in tts.response_format.lower()
+                if character.isalnum()
+            ) or "wav"
+            with tempfile.NamedTemporaryFile(
+                prefix=file_prefix,
+                suffix=f".{safe_format}",
+                delete=False,
+            ) as audio_file:
+                temporary_path = audio_file.name
+                audio_file.write(audio)
+
+            from core.ref import get_speaker
+
+            speaker = get_speaker()
+            if not speaker:
+                raise RuntimeError("Speaker manager is not available")
+            played = await speaker.play_server_file(
+                file_path=temporary_path,
+                blocking=True,
+            )
+            if played is False:
+                raise RuntimeError("SpeakerManager.play_server_file returned false")
+        finally:
+            if temporary_path:
+                try:
+                    os.unlink(temporary_path)
+                except FileNotFoundError:
+                    pass
+                except OSError as exc:
+                    logger.warning(
+                        f"[{log_name} TTS] Failed to remove temporary "
+                        f"audio file {temporary_path}: {exc}"
+                    )
+
+    @classmethod
+    async def _fallback_to_xiaoai(cls, text: str, *, log_prefix: str) -> None:
+        try:
+            from core.ref import get_speaker
+
+            speaker = get_speaker()
+            if speaker:
+                await speaker.play(text=text, blocking=True)
+        except Exception as exc:
+            logger.error(f"[{log_prefix}] XiaoAI TTS fallback failed: {exc}")

--- a/tests/test_mlx_audio_tts.py
+++ b/tests/test_mlx_audio_tts.py
@@ -1,0 +1,295 @@
+import asyncio
+import importlib
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+ROOT = importlib.import_module("pathlib").Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+tts_module = importlib.import_module("core.services.tts.mlx_audio")
+MLXAudioTTS = tts_module.MLXAudioTTS
+MLXAudioTTSTimeoutError = tts_module.MLXAudioTTSTimeoutError
+
+
+class FakeResponse:
+    def __init__(
+        self,
+        status=200,
+        body=b"RIFF-audio",
+        read_error=None,
+        content_type="audio/wav",
+    ):
+        self.status = status
+        self.body = body
+        self.read_error = read_error
+        self.content_type = content_type
+
+    async def read(self):
+        if self.read_error:
+            raise self.read_error
+        return self.body
+
+
+class ResponseContext:
+    def __init__(self, response=None, enter_error=None):
+        self.response = response
+        self.enter_error = enter_error
+
+    async def __aenter__(self):
+        if self.enter_error:
+            raise self.enter_error
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class FakeSession:
+    def __init__(self, response=None, enter_error=None):
+        self.response = response
+        self.enter_error = enter_error
+        self.url = None
+        self.request_kwargs = None
+
+    async def __aenter__(self):
+        if self.enter_error:
+            raise self.enter_error
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    def post(self, url, **kwargs):
+        self.url = url
+        self.request_kwargs = kwargs
+        return ResponseContext(self.response, self.enter_error)
+
+
+class MLXAudioTTSTest(unittest.IsolatedAsyncioTestCase):
+    async def test_voice_design_posts_instruction_without_preset_voice(self):
+        session = FakeSession(FakeResponse())
+        tts = MLXAudioTTS(
+            base_url="http://mlx-audio:8000/v1",
+            model="mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-6bit",
+            mode="voice_design",
+            voice="Dylan",
+            lang_code="Chinese",
+            response_format="wav",
+            instruct="年轻中文男声，标准普通话，无明显地域口音。",
+        )
+
+        with patch.object(tts_module.aiohttp, "ClientSession", return_value=session):
+            with patch.object(tts_module.aiohttp, "ClientTimeout", side_effect=lambda total: total):
+                await tts.synthesize("你好，这是一次音色测试。")
+
+        self.assertEqual(
+            {
+                "model": "mlx-community/Qwen3-TTS-12Hz-1.7B-VoiceDesign-6bit",
+                "input": "你好，这是一次音色测试。",
+                "lang_code": "Chinese",
+                "response_format": "wav",
+                "speed": 1.0,
+                "instruct": "年轻中文男声，标准普通话，无明显地域口音。",
+            },
+            session.request_kwargs["json"],
+        )
+
+    async def test_synthesize_posts_mlx_audio_speech_payload(self):
+        session = FakeSession(FakeResponse())
+        tts = MLXAudioTTS(
+            base_url="http://mlx-audio:8000/v1",
+            api_key="secret",
+            model="Qwen3-TTS",
+            voice="Vivian",
+            lang_code="Chinese",
+            response_format="wav",
+            speed=1.25,
+            instruct="用温柔的语气",
+            timeout=7,
+            extra_body={"custom_field": "enabled"},
+        )
+
+        with patch.object(tts_module.aiohttp, "ClientSession", return_value=session):
+            with patch.object(tts_module.aiohttp, "ClientTimeout", side_effect=lambda total: total):
+                audio = await tts.synthesize("你好")
+
+        self.assertEqual(b"RIFF-audio", audio)
+        self.assertEqual("http://mlx-audio:8000/v1/audio/speech", session.url)
+        self.assertEqual(
+            {
+                "model": "Qwen3-TTS",
+                "input": "你好",
+                "voice": "Vivian",
+                "lang_code": "Chinese",
+                "response_format": "wav",
+                "speed": 1.25,
+                "instruct": "用温柔的语气",
+                "custom_field": "enabled",
+            },
+            session.request_kwargs["json"],
+        )
+        self.assertEqual(
+            {
+                "Content-Type": "application/json",
+                "Authorization": "Bearer secret",
+            },
+            session.request_kwargs["headers"],
+        )
+
+    async def test_synthesize_raises_clear_error_for_non_success_response(self):
+        session = FakeSession(FakeResponse(status=503, body=b"service unavailable"))
+        tts = MLXAudioTTS(base_url="http://mlx-audio:8000/v1")
+
+        with patch.object(tts_module.aiohttp, "ClientSession", return_value=session):
+            with patch.object(tts_module.aiohttp, "ClientTimeout", side_effect=lambda total: total):
+                with self.assertRaisesRegex(RuntimeError, "HTTP 503.*service unavailable"):
+                    await tts.synthesize("你好")
+
+    async def test_synthesize_converts_request_timeout(self):
+        session = FakeSession(enter_error=asyncio.TimeoutError())
+        tts = MLXAudioTTS(base_url="http://mlx-audio:8000/v1", timeout=3)
+
+        with patch.object(tts_module.aiohttp, "ClientSession", return_value=session):
+            with patch.object(tts_module.aiohttp, "ClientTimeout", side_effect=lambda total: total):
+                with self.assertRaises(MLXAudioTTSTimeoutError):
+                    await tts.synthesize("你好")
+
+    async def test_synthesize_rejects_successful_non_audio_response(self):
+        session = FakeSession(
+            FakeResponse(body=b'{"error":"not audio"}', content_type="application/json")
+        )
+        tts = MLXAudioTTS(base_url="http://mlx-audio:8000/v1")
+
+        with patch.object(tts_module.aiohttp, "ClientSession", return_value=session):
+            with patch.object(tts_module.aiohttp, "ClientTimeout", side_effect=lambda total: total):
+                with self.assertRaisesRegex(RuntimeError, "unexpected content type"):
+                    await tts.synthesize("你好")
+
+    def test_invalid_mode_is_rejected(self):
+        with self.assertRaisesRegex(ValueError, "mode must be one of"):
+            MLXAudioTTS(mode="voice-design")
+
+    def test_streaming_config_is_rejected_by_file_adapter(self):
+        with self.assertRaisesRegex(ValueError, "does not support stream=true"):
+            MLXAudioTTS(extra_body={"stream": True})
+
+    def test_output_format_must_be_supported_by_bridge_decoder(self):
+        with self.assertRaisesRegex(ValueError, "response_format must be one of"):
+            MLXAudioTTS(response_format="opus")
+
+
+class MLXAudioTTSFallbackTest(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(cls):
+        sys.modules.setdefault("open_xiaoai_server", types.SimpleNamespace())
+        sys.modules.setdefault(
+            "aiohttp",
+            types.SimpleNamespace(ClientSession=object, ClientTimeout=object),
+        )
+        cls.openai_module = importlib.import_module("core.openai")
+        cls.manager = cls.openai_module.OpenAIManager
+        cls.config_manager = importlib.import_module("core.utils.config").ConfigManager
+        cls.adapter = MLXAudioTTS
+
+    def setUp(self):
+        self.previous_provider = self.manager._tts_provider
+        self.previous_speaker = self.manager._tts_speaker
+        self.previous_session_speakers = self.manager._session_tts_speakers
+        self.manager._tts_provider = "mlx_audio"
+        self.manager._tts_speaker = None
+        self.manager._session_tts_speakers = {}
+
+    def tearDown(self):
+        self.manager._tts_provider = self.previous_provider
+        self.manager._tts_speaker = self.previous_speaker
+        self.manager._session_tts_speakers = self.previous_session_speakers
+
+    async def test_success_plays_server_file_and_removes_temporary_audio(self):
+        speaker = unittest.mock.MagicMock()
+        speaker.play_server_file = unittest.mock.AsyncMock(return_value=True)
+        speaker.play = unittest.mock.AsyncMock()
+        config = {
+            "base_url": "http://mlx-audio:8000/v1",
+            "model": "Qwen3-TTS",
+            "voice": "Vivian",
+            "response_format": "wav",
+        }
+
+        with patch.object(
+            self.config_manager.instance(), "get_app_config", return_value=config
+        ):
+            with patch.object(
+                self.adapter, "synthesize", new=unittest.mock.AsyncMock(return_value=b"RIFF-audio")
+            ):
+                with patch.object(
+                    importlib.import_module("core.ref"), "get_speaker", return_value=speaker
+                ):
+                    await self.manager._play_response_with_tts(
+                        "你好", tts_speaker="Vivian"
+                    )
+
+        speaker.play_server_file.assert_awaited_once()
+        audio_path = speaker.play_server_file.await_args.kwargs["file_path"]
+        self.assertFalse(importlib.import_module("os").path.exists(audio_path))
+        speaker.play.assert_not_awaited()
+
+    async def test_playback_error_falls_back_and_still_removes_temporary_audio(self):
+        speaker = unittest.mock.MagicMock()
+        speaker.play_server_file = unittest.mock.AsyncMock(
+            side_effect=RuntimeError("rust playback failed")
+        )
+        speaker.play = unittest.mock.AsyncMock(return_value=True)
+        config = {"base_url": "http://mlx-audio:8000/v1", "response_format": "wav"}
+
+        with patch.object(
+            self.config_manager.instance(), "get_app_config", return_value=config
+        ):
+            with patch.object(
+                self.adapter, "synthesize", new=unittest.mock.AsyncMock(return_value=b"RIFF-audio")
+            ):
+                with patch.object(
+                    importlib.import_module("core.ref"), "get_speaker", return_value=speaker
+                ):
+                    await self.manager._play_response_with_tts("你好")
+
+        audio_path = speaker.play_server_file.await_args.kwargs["file_path"]
+        self.assertFalse(importlib.import_module("os").path.exists(audio_path))
+        speaker.play.assert_awaited_once_with(text="你好", blocking=True)
+
+    async def test_tts_timeout_falls_back_to_xiaoai_native_tts(self):
+        speaker = unittest.mock.MagicMock()
+        speaker.play = unittest.mock.AsyncMock(return_value=True)
+        config = {"base_url": "http://mlx-audio:8000/v1"}
+
+        with patch.object(
+            self.config_manager.instance(), "get_app_config", return_value=config
+        ):
+            with patch.object(
+                self.adapter,
+                "synthesize",
+                new=unittest.mock.AsyncMock(
+                    side_effect=MLXAudioTTSTimeoutError("request timed out")
+                ),
+            ):
+                with patch.object(
+                    importlib.import_module("core.ref"), "get_speaker", return_value=speaker
+                ):
+                    await self.manager._play_response_with_tts("你好")
+
+        speaker.play.assert_awaited_once_with(text="你好", blocking=True)
+
+    def test_missing_provider_keeps_legacy_xiaoai_and_doubao_selection(self):
+        self.manager._tts_provider = None
+        self.assertEqual(
+            "xiaoai", self.manager._resolve_tts_provider("xiaoai")
+        )
+        self.assertEqual("doubao", self.manager._resolve_tts_provider(None))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_mlx_audio_tts.py
+++ b/tests/test_mlx_audio_tts.py
@@ -12,6 +12,7 @@ if str(ROOT) not in sys.path:
 
 
 tts_module = importlib.import_module("core.services.tts.mlx_audio")
+protocol_module = importlib.import_module("core.services.tts.openai")
 MLXAudioTTS = tts_module.MLXAudioTTS
 MLXAudioTTSTimeoutError = tts_module.MLXAudioTTSTimeoutError
 
@@ -83,8 +84,8 @@ class MLXAudioTTSTest(unittest.IsolatedAsyncioTestCase):
             instruct="年轻中文男声，标准普通话，无明显地域口音。",
         )
 
-        with patch.object(tts_module.aiohttp, "ClientSession", return_value=session):
-            with patch.object(tts_module.aiohttp, "ClientTimeout", side_effect=lambda total: total):
+        with patch.object(protocol_module.aiohttp, "ClientSession", return_value=session):
+            with patch.object(protocol_module.aiohttp, "ClientTimeout", side_effect=lambda total: total):
                 await tts.synthesize("你好，这是一次音色测试。")
 
         self.assertEqual(
@@ -114,8 +115,8 @@ class MLXAudioTTSTest(unittest.IsolatedAsyncioTestCase):
             extra_body={"custom_field": "enabled"},
         )
 
-        with patch.object(tts_module.aiohttp, "ClientSession", return_value=session):
-            with patch.object(tts_module.aiohttp, "ClientTimeout", side_effect=lambda total: total):
+        with patch.object(protocol_module.aiohttp, "ClientSession", return_value=session):
+            with patch.object(protocol_module.aiohttp, "ClientTimeout", side_effect=lambda total: total):
                 audio = await tts.synthesize("你好")
 
         self.assertEqual(b"RIFF-audio", audio)
@@ -145,8 +146,8 @@ class MLXAudioTTSTest(unittest.IsolatedAsyncioTestCase):
         session = FakeSession(FakeResponse(status=503, body=b"service unavailable"))
         tts = MLXAudioTTS(base_url="http://mlx-audio:8000/v1")
 
-        with patch.object(tts_module.aiohttp, "ClientSession", return_value=session):
-            with patch.object(tts_module.aiohttp, "ClientTimeout", side_effect=lambda total: total):
+        with patch.object(protocol_module.aiohttp, "ClientSession", return_value=session):
+            with patch.object(protocol_module.aiohttp, "ClientTimeout", side_effect=lambda total: total):
                 with self.assertRaisesRegex(RuntimeError, "HTTP 503.*service unavailable"):
                     await tts.synthesize("你好")
 
@@ -154,8 +155,8 @@ class MLXAudioTTSTest(unittest.IsolatedAsyncioTestCase):
         session = FakeSession(enter_error=asyncio.TimeoutError())
         tts = MLXAudioTTS(base_url="http://mlx-audio:8000/v1", timeout=3)
 
-        with patch.object(tts_module.aiohttp, "ClientSession", return_value=session):
-            with patch.object(tts_module.aiohttp, "ClientTimeout", side_effect=lambda total: total):
+        with patch.object(protocol_module.aiohttp, "ClientSession", return_value=session):
+            with patch.object(protocol_module.aiohttp, "ClientTimeout", side_effect=lambda total: total):
                 with self.assertRaises(MLXAudioTTSTimeoutError):
                     await tts.synthesize("你好")
 
@@ -165,8 +166,8 @@ class MLXAudioTTSTest(unittest.IsolatedAsyncioTestCase):
         )
         tts = MLXAudioTTS(base_url="http://mlx-audio:8000/v1")
 
-        with patch.object(tts_module.aiohttp, "ClientSession", return_value=session):
-            with patch.object(tts_module.aiohttp, "ClientTimeout", side_effect=lambda total: total):
+        with patch.object(protocol_module.aiohttp, "ClientSession", return_value=session):
+            with patch.object(protocol_module.aiohttp, "ClientTimeout", side_effect=lambda total: total):
                 with self.assertRaisesRegex(RuntimeError, "unexpected content type"):
                     await tts.synthesize("你好")
 
@@ -178,9 +179,18 @@ class MLXAudioTTSTest(unittest.IsolatedAsyncioTestCase):
         with self.assertRaisesRegex(ValueError, "does not support stream=true"):
             MLXAudioTTS(extra_body={"stream": True})
 
-    def test_output_format_must_be_supported_by_bridge_decoder(self):
+    def test_standard_instructions_are_mapped_to_mlx_instruct(self):
+        tts = MLXAudioTTS(instructions="自然、放松地说话")
+
+        self.assertEqual(
+            "自然、放松地说话",
+            tts._payload("你好")["instruct"],
+        )
+        self.assertNotIn("instructions", tts._payload("你好"))
+
+    def test_output_format_must_be_supported_by_mlx_server(self):
         with self.assertRaisesRegex(ValueError, "response_format must be one of"):
-            MLXAudioTTS(response_format="opus")
+            MLXAudioTTS(response_format="aac")
 
 
 class MLXAudioTTSFallbackTest(unittest.IsolatedAsyncioTestCase):

--- a/tests/test_openai_tts.py
+++ b/tests/test_openai_tts.py
@@ -1,0 +1,221 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest.mock import patch
+
+
+ROOT = importlib.import_module("pathlib").Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+
+tts_module = importlib.import_module("core.services.tts.openai")
+OpenAITTS = tts_module.OpenAITTS
+sys.modules.setdefault("open_xiaoai_server", types.SimpleNamespace())
+
+
+class FakeResponse:
+    def __init__(self, status=200, body=b"audio", content_type="audio/mpeg"):
+        self.status = status
+        self.body = body
+        self.content_type = content_type
+
+    async def read(self):
+        return self.body
+
+
+class ResponseContext:
+    def __init__(self, response):
+        self.response = response
+
+    async def __aenter__(self):
+        return self.response
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+
+class FakeSession:
+    def __init__(self, response):
+        self.response = response
+        self.url = None
+        self.request_kwargs = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, traceback):
+        return False
+
+    def post(self, url, **kwargs):
+        self.url = url
+        self.request_kwargs = kwargs
+        return ResponseContext(self.response)
+
+
+class OpenAITTSTest(unittest.IsolatedAsyncioTestCase):
+    async def test_posts_standard_openai_speech_payload(self):
+        session = FakeSession(FakeResponse())
+        tts = OpenAITTS(
+            base_url="http://tts.example/v1",
+            api_key="secret",
+            model="gpt-4o-mini-tts",
+            voice={"id": "voice_123"},
+            instructions="自然、放松地说话",
+            response_format="opus",
+            speed=1.25,
+            extra_body={"custom_field": "enabled"},
+        )
+
+        with patch.object(tts_module.aiohttp, "ClientSession", return_value=session):
+            with patch.object(
+                tts_module.aiohttp,
+                "ClientTimeout",
+                side_effect=lambda total: total,
+            ):
+                audio = await tts.synthesize("你好")
+
+        self.assertEqual(b"audio", audio)
+        self.assertEqual("http://tts.example/v1/audio/speech", session.url)
+        self.assertEqual(
+            {
+                "model": "gpt-4o-mini-tts",
+                "input": "你好",
+                "voice": {"id": "voice_123"},
+                "instructions": "自然、放松地说话",
+                "response_format": "opus",
+                "speed": 1.25,
+                "custom_field": "enabled",
+            },
+            session.request_kwargs["json"],
+        )
+        self.assertEqual(
+            {
+                "Content-Type": "application/json",
+                "Authorization": "Bearer secret",
+            },
+            session.request_kwargs["headers"],
+        )
+
+    def test_supports_official_non_streaming_formats(self):
+        for response_format in ("mp3", "opus", "aac", "flac", "wav", "pcm"):
+            self.assertEqual(
+                response_format,
+                OpenAITTS(response_format=response_format).response_format,
+            )
+
+    def test_rejects_sse_streaming(self):
+        with self.assertRaisesRegex(ValueError, "stream_format='sse'"):
+            OpenAITTS(stream_format="sse")
+
+    def test_rejects_stream_body_extension(self):
+        with self.assertRaisesRegex(ValueError, "stream=true"):
+            OpenAITTS(extra_body={"stream": True})
+
+    def test_rejects_sse_stream_body_extension(self):
+        with self.assertRaisesRegex(ValueError, "stream_format='sse'"):
+            OpenAITTS(extra_body={"stream_format": "sse"})
+
+    def test_rejects_speed_outside_official_range(self):
+        with self.assertRaisesRegex(ValueError, "between 0.25 and 4.0"):
+            OpenAITTS(speed=4.1)
+
+    def test_from_config_allows_voice_override(self):
+        tts = OpenAITTS.from_config(
+            {
+                "base_url": "http://tts.example/v1",
+                "voice": "alloy",
+            },
+            voice_override="sage",
+        )
+        self.assertEqual("sage", tts.voice)
+
+    def test_rejects_custom_voice_without_id(self):
+        with self.assertRaisesRegex(ValueError, "must include an id"):
+            OpenAITTS(voice={"name": "custom"})
+
+
+class OpenAITTSPlaybackTest(unittest.IsolatedAsyncioTestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.openai_module = importlib.import_module("core.openai")
+        cls.manager = cls.openai_module.OpenAIManager
+        cls.config_manager = importlib.import_module(
+            "core.utils.config"
+        ).ConfigManager
+
+    def setUp(self):
+        self.previous_provider = self.manager._tts_provider
+        self.previous_speaker = self.manager._tts_speaker
+        self.previous_session_speakers = self.manager._session_tts_speakers
+        self.manager._tts_provider = "openai"
+        self.manager._tts_speaker = None
+        self.manager._session_tts_speakers = {}
+
+    def tearDown(self):
+        self.manager._tts_provider = self.previous_provider
+        self.manager._tts_speaker = self.previous_speaker
+        self.manager._session_tts_speakers = self.previous_session_speakers
+
+    async def test_openai_provider_uses_shared_file_playback(self):
+        speaker = unittest.mock.MagicMock()
+        speaker.play_server_file = unittest.mock.AsyncMock(return_value=True)
+        speaker.play = unittest.mock.AsyncMock()
+        config = {
+            "base_url": "http://tts.example/v1",
+            "model": "gpt-4o-mini-tts",
+            "voice": "alloy",
+            "response_format": "wav",
+        }
+
+        with patch.object(
+            self.config_manager.instance(), "get_app_config", return_value=config
+        ):
+            with patch.object(
+                OpenAITTS,
+                "synthesize",
+                new=unittest.mock.AsyncMock(return_value=b"RIFF-audio"),
+            ):
+                with patch.object(
+                    importlib.import_module("core.ref"),
+                    "get_speaker",
+                    return_value=speaker,
+                ):
+                    await self.manager._play_response_with_tts(
+                        "你好", tts_speaker="sage"
+                    )
+
+        speaker.play_server_file.assert_awaited_once()
+        audio_path = speaker.play_server_file.await_args.kwargs["file_path"]
+        self.assertFalse(importlib.import_module("os").path.exists(audio_path))
+        speaker.play.assert_not_awaited()
+
+    async def test_unsupported_playback_format_falls_back_before_request(self):
+        speaker = unittest.mock.MagicMock()
+        speaker.play = unittest.mock.AsyncMock(return_value=True)
+        config = {
+            "base_url": "http://tts.example/v1",
+            "response_format": "opus",
+        }
+        synthesize = unittest.mock.AsyncMock(return_value=b"audio")
+
+        with patch.object(
+            self.config_manager.instance(), "get_app_config", return_value=config
+        ):
+            with patch.object(OpenAITTS, "synthesize", new=synthesize):
+                with patch.object(
+                    importlib.import_module("core.ref"),
+                    "get_speaker",
+                    return_value=speaker,
+                ):
+                    await self.manager._play_response_with_tts(
+                        "你好", tts_speaker="alloy"
+                    )
+
+        synthesize.assert_not_awaited()
+        speaker.play.assert_awaited_once_with(text="你好", blocking=True)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_tts_router.py
+++ b/tests/test_tts_router.py
@@ -1,0 +1,149 @@
+import importlib
+import sys
+import types
+import unittest
+from unittest.mock import AsyncMock, patch
+
+
+sys.modules.setdefault("open_xiaoai_server", types.SimpleNamespace())
+
+router_module = importlib.import_module("core.services.tts.router")
+TTSRouter = router_module.TTSRouter
+
+
+class TTSRouterProviderTest(unittest.TestCase):
+    def test_explicit_provider_is_shared_by_all_backends(self):
+        for provider in ("xiaoai", "doubao", "openai", "mlx_audio"):
+            self.assertEqual(
+                provider,
+                TTSRouter.resolve_provider(provider, "xiaoai"),
+            )
+
+    def test_missing_provider_preserves_legacy_speaker_selection(self):
+        self.assertEqual("xiaoai", TTSRouter.resolve_provider(None, "xiaoai"))
+        self.assertEqual("doubao", TTSRouter.resolve_provider(None, None))
+        self.assertEqual("doubao", TTSRouter.resolve_provider(None, "alloy"))
+
+
+class BackendTTSProviderConfigTest(unittest.TestCase):
+    def test_openclaw_reads_tts_provider_without_changing_existing_speaker_keys(self):
+        module = importlib.import_module("core.openclaw")
+        manager = module.OpenClawManager
+        config = {
+            "tts_provider": "mlx_audio",
+            "tts_speaker": "xiaoai",
+            "agent_tts_speakers": {"assistant": "xiaoai"},
+        }
+        config_manager = types.SimpleNamespace(
+            get_app_config=lambda *_args: config,
+            add_reload_listener=lambda *_args: None,
+        )
+        previous_listener_state = manager._reload_listener_registered
+        try:
+            manager._reload_listener_registered = False
+            with patch.object(
+                module.ConfigManager, "instance", return_value=config_manager
+            ):
+                manager.reload_from_config(enabled=True)
+            self.assertEqual("mlx_audio", manager._tts_provider)
+            self.assertEqual("xiaoai", manager._tts_speaker)
+            self.assertEqual({"assistant": "xiaoai"}, manager._agent_tts_speakers)
+        finally:
+            manager._reload_listener_registered = previous_listener_state
+
+    def test_qwenpaw_reads_tts_provider_without_changing_existing_speaker_keys(self):
+        module = importlib.import_module("core.qwenpaw")
+        manager = module.QwenPawManager
+        config = {
+            "tts_provider": "openai",
+            "tts_speaker": "sage",
+            "session_tts_speakers": {"agent:default:main": "sage"},
+        }
+        config_manager = types.SimpleNamespace(
+            get_app_config=lambda *_args: config,
+            add_reload_listener=lambda *_args: None,
+        )
+        previous_listener_state = manager._reload_listener_registered
+        try:
+            manager._reload_listener_registered = False
+            with patch.object(
+                module.ConfigManager, "instance", return_value=config_manager
+            ):
+                manager.reload_from_config(enabled=True)
+            self.assertEqual("openai", manager._tts_provider)
+            self.assertEqual("sage", manager._tts_speaker)
+            self.assertEqual(
+                {"agent:default:main": "sage"}, manager._session_tts_speakers
+            )
+        finally:
+            manager._reload_listener_registered = previous_listener_state
+
+
+class BackendTTSRoutingTest(unittest.IsolatedAsyncioTestCase):
+    async def test_openclaw_delegates_to_shared_router(self):
+        module = importlib.import_module("core.openclaw")
+        manager = module.OpenClawManager
+        previous = (
+            manager._tts_provider,
+            manager._tts_speaker,
+            manager._tts_speed,
+            manager._session_key,
+            manager._initialized,
+        )
+        manager._tts_provider = "mlx_audio"
+        manager._tts_speaker = "xiaoai"
+        manager._tts_speed = 1.1
+        manager._session_key = "agent:assistant:main"
+        manager._initialized = True
+        try:
+            with patch.object(
+                router_module.TTSRouter, "play", new=AsyncMock()
+            ) as play:
+                await manager._play_response_with_tts("你好", playback_token=7)
+            play.assert_awaited_once_with(
+                "你好",
+                configured_provider="mlx_audio",
+                tts_speaker="xiaoai",
+                tts_speed=1.1,
+                playback_token=7,
+                log_prefix="OpenClaw",
+            )
+        finally:
+            (
+                manager._tts_provider,
+                manager._tts_speaker,
+                manager._tts_speed,
+                manager._session_key,
+                manager._initialized,
+            ) = previous
+
+    async def test_qwenpaw_delegates_to_shared_router(self):
+        module = importlib.import_module("core.qwenpaw")
+        manager = module.QwenPawManager
+        previous = (
+            manager._tts_provider,
+            manager._tts_speaker,
+            manager._tts_speed,
+        )
+        manager._tts_provider = "openai"
+        manager._tts_speaker = "sage"
+        manager._tts_speed = 0.9
+        try:
+            with patch.object(
+                router_module.TTSRouter, "play", new=AsyncMock()
+            ) as play:
+                await manager._play_response_with_tts("你好", playback_token=8)
+            play.assert_awaited_once_with(
+                "你好",
+                configured_provider="openai",
+                tts_speaker="sage",
+                tts_speed=0.9,
+                playback_token=8,
+                log_prefix="QwenPaw",
+            )
+        finally:
+            manager._tts_provider, manager._tts_speaker, manager._tts_speed = previous
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 概述

本 PR 为 OpenAI、OpenClaw 和 QwenPaw 三个对话后端增加统一的可配置 TTS provider，同时保持现有配置结构和旧配置兼容。

## 主要改动

- 新增 OpenAI-compatible TTS 客户端，支持：
  - 官方 OpenAI
  - 其他兼容 `POST /v1/audio/speech` 的服务
  - `model`、`input`、`voice`、`instructions`、`response_format`、`speed` 等标准字段
- 新增 `mlx_audio` provider：
  - 支持 Apple Silicon 本地 MLX-Audio
  - 支持 VoiceDesign 和 CustomVoice
  - 支持 `instruct`、`lang_code` 等 MLX-Audio 参数
- 新增共享 `TTSRouter`：
  - OpenAI、OpenClaw、QwenPaw 都可以使用：
    - `xiaoai`
    - `doubao`
    - `openai`
    - `mlx_audio`
  - 统一处理 provider 选择、音频文件播放、临时文件清理和小爱原生 TTS fallback
- 为 OpenClaw 和 QwenPaw 增加可选的 `tts_provider` 配置。
- 保留原有的 `tts_speaker`、`session_tts_speakers` 和 `agent_tts_speakers` 配置。
- README 新增独立的 TTS 配置章节，说明四种 provider 的配置方式。
- 增加 provider 路由、配置读取、协议请求、播放清理和 fallback 测试。

## 配置示例

```python
"openai": {
    "tts_provider": "mlx_audio",
    "tts_speaker": "xiaoai",
},

"openclaw": {
    "tts_provider": "doubao",
    "tts_speaker": "zh_male_raphael_bigtts",
},

"qwenpaw": {
    "tts_provider": "xiaoai",
    "tts_speaker": "xiaoai",
},
```

现有的 `tts.openai`、`tts.mlx_audio` 和 `tts.doubao` 配置保持不变，不引入新的 profile 或配置层级。

如果不填写 `tts_provider`，则保持原有行为：

- `tts_speaker = "xiaoai"` 使用小爱原生 TTS
- 其他音色 ID 使用豆包 TTS

## 音频与流式行为

- 豆包 TTS 保留现有的 PCM / MP3 流式播放能力。
- OpenAI 和 MLX-Audio 使用完整音频文件播放。
- OpenAI / MLX-Audio 不接受当前音箱播放链路无法安全处理的 SSE 流式配置。
- 音频文件播放失败或 TTS 请求失败时，自动 fallback 到小爱原生 TTS。

## 范围说明

本 PR 修改的是三个对话后端的自动回复播报链路。

Agent 主动调用的 `xiaoai-tts` skill，以及专用的 `/api/tts/doubao` 接口保持不变。

## 验证

- `python -m unittest discover -s tests -v` — 59 个通过，3 个已有 Live OpenClaw 测试跳过
- `python -m unittest discover -s tests -p 'test_tts_router.py' -v` — 6 个通过
- Python 语法检查通过
- `git diff --check` 通过
- `docker compose config -q` 通过
- Docker 镜像及 Rust 原生扩展构建成功
- 容器内验证四种 provider 和三个后端的 TTS 入口均可正常导入