### PR TITLE
新增独立 Hermes Agent 后端

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,6 +1,6 @@
 # AGENTS.md
 
-> 小爱音箱与外部 AI 服务（小智 AI、OpenClaw）的桥接器。
+> 小爱音箱与外部 AI 服务（小智 AI、OpenClaw、OpenAI-compatible、Hermes 等）的桥接器。
 > 接管音箱音频输入输出，实现与第三方 AI 的对话。
 
 ## 系统架构
@@ -20,6 +20,13 @@ open-xiaoai-bridge/
 │   ├── xiaozhi.py                 # 小智 AI WebSocket 协议客户端
 │   ├── openclaw.py                # OpenClaw 网关客户端（连接、消息、TTS 播放）
 │   ├── openclaw_conversation.py   # OpenClaw 连续对话循环（VAD → ASR → Agent → TTS）
+│   ├── openai.py                  # 普通 OpenAI-compatible 非流式后端
+│   ├── hermes.py                  # Hermes 专用 Manager 与流式协议入口
+│   ├── hermes_conversation.py     # Hermes 连续对话与顺序语音控制
+│   ├── hermes_progress.py         # Hermes 工具进度的安全自然语言分类
+│   ├── openai_stream.py           # 协议中立的标准 SSE 文本解析
+│   ├── streaming_conversation.py  # 可复用的流式回复语音交付
+│   ├── speech_queue.py            # 单工作线程顺序语音队列
 │   ├── wakeup_session.py          # 小智唤醒会话状态机
 │   ├── ref.py                     # 全局引用注册表（get/set 依赖注入）
 │   ├── models/                    # 模型文件（KWS/VAD/ASR，.gitignore 排除）
@@ -67,6 +74,8 @@ open-xiaoai-bridge/
 - `send_text(text)` → 发送文本到小智
 - `send_to_openclaw(text, wait_response)` → 发送消息到 OpenClaw（返回 run_id 或回复文本）
 - `send_to_openclaw_and_play_reply(text, wait_response)` → 发送并 TTS 播放回复
+- `send_to_hermes(text, wait_response)` → 发送消息到独立 Hermes 后端
+- `send_to_hermes_and_play_reply(text, wait_response)` → 发送并 TTS 播放 Hermes 回复
 - `schedule(callback)` → 主线程任务队列
 - `shutdown()` → 优雅关闭
 
@@ -158,11 +167,22 @@ OpenClaw 连续对话控制器。唤醒词触发后进入独立的 VAD → ASR �
 - TTS 完全阻塞，播放完成后才继续监听
 - 自己持有并管理当前 TTS 的 `playback_token`；停止 OpenClaw 对话时应调用 `stop_tts_playback(token)`，不要在外层直接无 token 全局停止 Rust TTS
 
+### HermesManager / HermesConversationController
+
+Hermes 是独立后端，拥有自己的 `HERMES_ENABLE`、`hermes` 配置、Session 历史和连续对话控制器。普通 `OpenAIManager` 保持上游的非流式 OpenAI-compatible 行为，也不解释 Hermes 专属事件。
+
+- 标准 SSE 文本解析位于 `openai_stream.py`，不包含 Hermes 事件语义
+- `hermes.tool.progress` 只在 `hermes.py` / `hermes_progress.py` 中解释
+- `speech_queue.py` 使用单工作线程保证进度与最终回答不重叠、不乱序
+- 最终文本开始到达后丢弃尚未播放的进度；已经开始播放的进度不被粗暴打断
+- 流式传输失败时不重新提交同一个 Agent turn；交付已收到的正文并提示用户重试
+- Bridge 仅按显式 `response_mode` 选择 streaming 或 complete，不根据模型名、地址或失败结果自动猜测和切换模式
+
 ### WakeupSessionManager (core/wakeup_session.py)
 
-小智唤醒会话状态机，协调 KWS → VAD → 小智/OpenClaw 的唤醒流程。
+小智唤醒会话状态机，协调 KWS → VAD → 小智及各外部后端的唤醒流程。
 
-- `wakeup(text, source)` → 处理唤醒（调用 `before_wakeup` 钩子，路由到 XiaoZhi 或 OpenClaw）
+- `wakeup(text, source)` → 处理唤醒（调用 `before_wakeup` 钩子并路由）
 - `wait_next_step(timeout)` → 异步等待状态变化（带待决状态缓冲）
 - `update_step(step, step_data)` → 更新步骤
 - 事件回调：`on_interrupt()`, `on_wakeup()`, `on_tts_start()`, `on_tts_end()`, `on_speech()`, `on_silence()`
@@ -171,6 +191,9 @@ OpenClaw 连续对话控制器。唤醒词触发后进入独立的 VAD → ASR �
 **路由规则**（`before_wakeup` 返回值）:
 - `"xiaozhi"` → 走小智流程
 - `"openclaw"` → 走 OpenClaw 连续对话
+- `"openai"` → 走普通 OpenAI-compatible 连续对话
+- `"hermes"` → 走 Hermes 专用连续对话
+- `"qwenpaw"` → 走 QwenPaw 连续对话
 - `None` → 不处理（用户自行处理）
 
 **边界约束**:

--- a/Dockerfile
+++ b/Dockerfile
@@ -62,4 +62,4 @@ EXPOSE 9092
 
 # 先初始化关键词模型（小智或外部后端启用时），然后启动主程序
 # 兼容 OPENCLAW_ENABLE (新) 和 OPENCLAW_ENABLED (旧)
-CMD ["/bin/bash", "-c", "source /app/.venv/bin/activate && OPENCLAW_VAL=\"${OPENCLAW_ENABLE:-${OPENCLAW_ENABLED:-}}\"; if [[ \"${XIAOZHI_ENABLE:-}\" =~ ^(1|true|yes)$ ]] || [[ \"$OPENCLAW_VAL\" =~ ^(1|true|yes)$ ]] || [[ \"${OPENAI_ENABLE:-}\" =~ ^(1|true|yes)$ ]] || [[ \"${QWENPAW_ENABLE:-}\" =~ ^(1|true|yes)$ ]]; then python core/services/audio/kws/keywords.py; fi && python main.py"]
+CMD ["/bin/bash", "-c", "source /app/.venv/bin/activate && OPENCLAW_VAL=\"${OPENCLAW_ENABLE:-${OPENCLAW_ENABLED:-}}\"; if [[ \"${XIAOZHI_ENABLE:-}\" =~ ^(1|true|yes)$ ]] || [[ \"$OPENCLAW_VAL\" =~ ^(1|true|yes)$ ]] || [[ \"${OPENAI_ENABLE:-}\" =~ ^(1|true|yes)$ ]] || [[ \"${HERMES_ENABLE:-}\" =~ ^(1|true|yes)$ ]] || [[ \"${QWENPAW_ENABLE:-}\" =~ ^(1|true|yes)$ ]]; then python core/services/audio/kws/keywords.py; fi && python main.py"]

--- a/README.md
+++ b/README.md
@@ -6,13 +6,13 @@
 
 [![New](https://img.shields.io/badge/🎉_新功能-OpenClaw_支持_自定义唤醒词_|_连续对话_|_多_Agent_路由_|_克隆音色_|_流式播放-f97316)](https://github.com/coderzc/open-xiaoai-bridge/releases)
 
-**小爱音箱与外部 AI 服务（小智 AI、OpenClaw、OpenAI 兼容服务、QwenPaw）的桥接器**
+**小爱音箱与外部 AI 服务（小智 AI、OpenClaw、OpenAI 兼容服务、Hermes、QwenPaw）的桥接器**
 
 打破小爱音箱的封闭生态，灵活接入多种 AI 服务，提供 HTTP API 实现远程控制。
 
 [📺 演示 ①](https://www.bilibili.com/video/BV1DHcBz1Ex7) · [📺 演示 ②](https://www.bilibili.com/video/BV1UQQSBHEvg)
 
-[📖 快速开始](#-快速开始) · [🔌 OpenAI 兼容服务](#-openai-兼容服务) · [🐾 QwenPaw 集成](#-qwenpaw-集成) · [🦞 OpenClaw 集成](#-openclaw-集成) · [🔧 API 文档](#-api-server) · [🐛 常见问题](#-常见问题)
+[📖 快速开始](#-快速开始) · [🔌 OpenAI 兼容服务](#-openai-兼容服务) · [🪽 Hermes 后端](#-hermes-后端) · [🐾 QwenPaw 集成](#-qwenpaw-集成) · [🦞 OpenClaw 集成](#-openclaw-集成) · [🔧 API 文档](#-api-server) · [🐛 常见问题](#-常见问题)
 
 > 本项目受 [Open-XiaoAI](https://github.com/idootop/open-xiaoai) 启发，并参考其 `examples/xiaozhi/` 示例演进而来，现已作为独立项目持续维护。
 
@@ -25,6 +25,7 @@
 | 功能                 | 说明                                                                             |
 | ------------------ | ------------------------------------------------------------------------------ |
 | 🔌 **OpenAI 兼容服务** | 接入 Hermes Agent API Server、OpenAI、Ollama、LM Studio 等 `/v1/chat/completions` 服务 |
+| 🪽 **Hermes 后端** | 独立接入 Hermes，支持结构化工具进度、流式分段播报和独立 Session |
 | 🐾 **QwenPaw 集成**   | 接入 [QwenPaw](https://github.com/agentscope-ai/QwenPaw) HTTP Console 任务接口，支持指定 Agent 和会话 |
 | 🦞 **OpenClaw 集成** | 接入 [OpenClaw](https://github.com/openclaw/openclaw)，支持连续对话，可选豆包 TTS 或小爱原生 TTS  |
 | 🤖 **小智 AI 集成**    | 接入 [xiaozhi-esp32-server](https://github.com/xinnan-tech/xiaozhi-esp32-server) 实时音频流 |
@@ -50,9 +51,9 @@
 
 ### 📥 模型文件
 
-如果你启用小智 AI，或 OpenClaw / OpenAI 兼容服务 / QwenPaw 连续对话使用 `local_asr`，需要下载 `VAD + KWS + ASR` 模型文件。
+如果你启用小智 AI，或 OpenClaw / OpenAI 兼容服务 / Hermes / QwenPaw 连续对话使用 `local_asr`，需要下载 `VAD + KWS + ASR` 模型文件。
 
-如果 OpenClaw / OpenAI 兼容服务 / QwenPaw 连续对话使用 `xiaoai_asr`，只需要 `VAD + KWS`，不需要本地 ASR 模型。
+如果 OpenClaw / OpenAI 兼容服务 / Hermes / QwenPaw 连续对话使用 `xiaoai_asr`，只需要 `VAD + KWS`，不需要本地 ASR 模型。`local_asr` 使用 Bridge 本地 VAD/ASR 路径，`xiaoai_asr` 使用小爱原生 ASR；后者仍需要小爱设备和 Bridge 的相关能力正常。`HERMES_ENABLE=1` 时，Docker 的模型准备逻辑会按当前启动脚本参与对应的 KWS/ASR 准备，不代表会自动下载模型。
 
 1. 从 [releases](https://github.com/coderzc/open-xiaoai-bridge/releases/tag/vad-kws-asr-models) 下载模型压缩包
 2. 解压模型文件（路径见下方具体部署方式）
@@ -109,6 +110,7 @@ OPEN_XIAOAI_TOKEN=your-secret-token API_SERVER_ENABLE=1 ./scripts/start.sh
 | `XIAOZHI_ENABLE`     | 启用小智 AI     | 禁用            |
 | `OPENCLAW_ENABLE`    | 启用 OpenClaw | 禁用            |
 | `OPENAI_ENABLE` | 启用 OpenAI 兼容服务 | 禁用        |
+| `HERMES_ENABLE` | 启用 Hermes 专用后端 | 禁用        |
 | `QWENPAW_ENABLE` | 启用 QwenPaw | 禁用        |
 | `API_SERVER_ENABLE`  | 启用 HTTP API | 禁用            |
 | `AUDIO_INPUT_ENABLE` | 启用音频输入（关闭后小智/KWS/local\_asr不可用） | 启用            |
@@ -391,6 +393,132 @@ if "让小黑" in text:
 
 `base_url` 可以直接填到 `/v1`，框架会自动调用 `/chat/completions`；如果你的服务已经给出完整 `/v1/chat/completions` 地址，也可以直接填写完整地址。连续对话会按 `session_key` 保存最近 `history_max_messages` 条上下文；需要隔离多个助手时，可在唤醒前调用 `app.set_openai_session_key("assistant-name")`。
 
+普通 OpenAI 入口默认保持非流式，也不会解析 Hermes 专属事件。它仍可像以前一样基础连接 Hermes；需要结构化进度和流式语音能力时，再使用下面的 Hermes 专用后端。
+
+## 🪽 Hermes 后端
+
+Hermes 是独立于普通 OpenAI-compatible 入口的增强后端。它需要一个已经运行的 Hermes API Server；`open-xiaoai-bridge` 不会自动启动该服务。先确保 Bridge 所在进程或容器能够访问 Hermes，再启用入口。
+
+### 最小部署
+
+在 `docker-compose.yml` 的 `open-xiaoai-bridge.environment` 中取消注释并启用：
+
+```yaml
+- HERMES_ENABLE=1
+```
+
+然后在 `config.py` 的 `hermes` 中至少填写：
+
+```python
+"hermes": {
+    "base_url": "http://192.168.x.x:8642/v1",
+    "api_key": "",
+    "model": "hermes-agent",
+}
+```
+
+`base_url` 通常填写到 `/v1`。也可以使用同一 Docker 网络中的服务名，例如 `http://hermes:8642/v1`。地址必须是 **Bridge 容器/进程能够访问的地址**；在 Docker 中，`127.0.0.1` 指向 Bridge 容器自身，只有 Hermes API Server 与 Bridge 处于同一网络命名空间时才适用。Bridge 只负责调用 API，不负责启动 Hermes Agent。
+
+配置后按项目原有方式启动：
+
+```bash
+docker compose up -d
+```
+
+### 唤醒与开始对话
+
+Hermes 不创建新的唤醒系统，仍使用 `APP_CONFIG["wakeup"]["keywords"]` 和 `before_wakeup(...)`。在路由函数中返回 `"hermes"` 即可进入 Hermes 连续对话：
+
+```python
+async def before_wakeup(speaker, text, source, app):
+    if source == "kws" and "你好赫尔墨斯" in text:
+        await speaker.play(text="赫尔墨斯来了")
+        return "hermes"
+    if source == "xiaoai" and text == "召唤赫尔墨斯":
+        await speaker.abort_xiaoai()
+        return "hermes"
+```
+
+“你好赫尔墨斯”只是当前配置中的示例 KWS，可自由修改；“召唤赫尔墨斯”是小爱原生唤醒后识别到的指令示例，不是新的系统唤醒词；“小爱同学”仍由小米设备负责。通用路由返回值还包括 `"openclaw"`、`"openai"`、`"qwenpaw"`、`"xiaozhi"` 和 `None`。
+
+退出连续 Hermes 会话时，默认的 `exit_keywords`（`退出`、`停止`、`再见`）会结束 Hermes 对话，随后按现有 `after_wakeup` 配置处理。重新唤醒“小爱同学”时，Bridge 会停止当前 Hermes controller 和播放并回到正常小爱流程。
+
+### 输入模式
+
+`input_mode="local_asr"`（默认）使用 Bridge 本地 VAD + SherpaASR，需要准备本地 ASR 模型；`input_mode="xiaoai_asr"` 使用小爱原生 ASR，不需要本地 ASR 模型，但仍需要现有小爱设备/Bridge 能力正常。
+
+### streaming 与 complete
+
+`response_mode="streaming"` 是默认模式：使用 SSE，按句提前播放，并处理 Hermes `hermes.tool.progress`，可降低首句等待时间。`response_mode="complete"` 等待完整回答后一次性播放，不使用 SSE tool progress，交付路径更简单。两种模式都是显式用户选择；streaming 失败不会自动切换到 complete，也不会重新执行同一个 Agent turn。
+
+流式中断时，Bridge 会保留并播放已经收到的正文，再提示用户重新提问，避免工具副作用或整段回答被重复执行。
+
+### Prompt
+
+以下字段默认都可以留空：
+
+- `system_prompt`：发送给 Hermes 的系统级提示。
+- `rule_prompt`：自动播放/连续对话时追加的输出规则。
+- `rule_prompt_for_skill`：不自动播放、由 Agent 决定调用 Skill 时追加的规则。
+
+不要把私人 prompt 写入仓库示例；需要个性化时直接编辑部署环境中的 `config.py`。
+
+### TTS
+
+`tts_speaker="xiaoai"` 使用小爱原生 TTS。填写项目支持的 Doubao 音色 ID 时，使用现有 Doubao TTS 路径；`tts_speed` 仅在当前支持该参数的 provider（目前为 Doubao 路径）上生效。`session_tts_speakers` 是高级配置，可按 Session 覆盖音色。
+
+### Session 与 Profile
+
+默认情况下，同一个 `session_key` 会复用本地 history，并继续使用 Hermes 返回的 native `Session-Id`；重新唤醒 Hermes 不会自动生成一场全新的逻辑对话，用户无需手工填写 `Session-Id`。需要明确清理上下文时，调用 `reset_hermes_session()`，它会同时清理 Bridge history 和对应 native Session-Id。高级控制 API 还有 `set_hermes_session_key(...)`、`get_hermes_session_state()`；`session_header` 只是用于发送 Session-Key 的高级协议配置。
+
+Profile 是可选高级能力，普通聊天保持 `profile=""` 即可，不需要配置 `profile_api_keys`。设置命名 Profile 时，Bridge 会按 Hermes 官方 `/p/<profile>/v1/...` 形式自动构造 URL，因此 `base_url` 仍填写基础 `/v1` 地址，不要手工把 `/p/<profile>/v1` 写进去。不同 Profile 会隔离对应的 Session/history；命名 Profile 可在 `profile_api_keys` 中配置独立 API key。Profile 不是 OpenClaw agent ID。
+
+### Tool progress
+
+streaming 模式会使用真实的 `hermes.tool.progress` 事件。已知 Hermes built-in tool 会转换为简短、适合 TTS 的进度；unknown、custom、plugin 或 MCP 工具使用通用提示；没有真实 tool event 时，长时间等待使用通用等待提示。Bridge 不会根据用户问题里的“天气”“音乐”“飞书”等关键词猜测业务状态，也不会朗读 raw label、URL、文件路径、代码、参数或日志。最终正文优先于尚未开始的进度，已开始的语音按队列完成。
+
+### Hermes Agent 主动播报（可选高级能力）
+
+不安装 `xiaoai-tts` Skill，普通 Hermes request→response 聊天仍然正常。主动播报需要 Hermes 的 `xiaoai-tts` Skill 和 Bridge HTTP API；Compose 示例默认已启用 `API_SERVER_ENABLE=1`，本地运行时请按现有 API Server 配置启用。Skill 直接复用 `/api/play/text` 和 `/api/tts/doubao`，不会建立第二套播放服务：
+
+```bash
+HERMES_ROOT="${HERMES_HOME:-$HOME/.hermes}"
+cp -a skills/xiaoai-tts "$HERMES_ROOT/skills/xiaoai-tts"
+echo 'OPENXIAOAI_BASE_URL="http://bridge-host:9092"' >> "$HERMES_ROOT/.env"
+```
+
+在 Skill 中使用 `${HERMES_SKILL_DIR}/tools/xiaoai-tts tts "需要播报的文本" --blocking`，只有收到 `RESULT success=true completed=true` 才应声称播报成功。需要 Agent 自己决定何时播报时，调用 `app.send_to_hermes()`，并在部署配置的 `hermes.rule_prompt_for_skill` 中说明使用 `xiaoai-tts`；该路径不会自动播放 Hermes final，因此不会与主动播报重复。普通自动播放仍使用 `app.send_to_hermes_and_play_reply()`。
+
+### 常用与高级配置
+
+| 字段 | 默认值 | 作用 |
+| --- | --- | --- |
+| `base_url` | `http://127.0.0.1:8642/v1` | Hermes API Server 基础地址，通常到 `/v1` |
+| `api_key` | `""` | API 认证密钥 |
+| `model` | `"hermes-agent"` | 请求的模型名 |
+| `profile` | `""` | 可选 Hermes Profile，空值使用默认 Profile |
+| `profile_api_keys` | `{}` | 命名 Profile 的独立 API key |
+| `input_mode` | `"local_asr"` | `local_asr` 或 `xiaoai_asr` |
+| `session_key` | `agent:default:open-xiaoai-bridge` | 本地与 Hermes 长期记忆作用域 |
+| `session_header` | `X-Hermes-Session-Key` | 发送 Session-Key 的请求头，可留空 |
+| `system_prompt` | `""` | 系统级提示 |
+| `temperature` | `0.7` | 采样温度 |
+| `max_tokens` | `512` | 最大输出 token 数 |
+| `history_max_messages` | `20` | 本地 history 保留的消息数 |
+| `response_timeout` | `120` | 单次响应超时时间（秒） |
+| `response_mode` | `"streaming"` | `streaming` 或 `complete` |
+| `streaming.*` | 见 config.py | 分句最小/最大字符数 |
+| `progress.*` | 见 config.py | 等待与工具进度播报参数 |
+| `tts_speed` | `1.0` | 当前支持的 TTS provider 的语速 |
+| `tts_speaker` | `"xiaoai"` | 小爱原生或 Doubao 音色 |
+| `session_tts_speakers` | `{}` | 按 Session 覆盖音色 |
+| `exit_keywords` | `退出/停止/再见` | 结束 Hermes 连续对话的词 |
+| `rule_prompt` | `""` | 自动播放/连续对话规则 |
+| `rule_prompt_for_skill` | `""` | Skill 主动播报场景规则 |
+| `extra_body` | `{}` | 追加到请求体的高级字段 |
+
+完整字段和默认值以当前 `config.py` 为准；普通用户只需配置最小示例，其他字段保持默认即可。
+
 ## 🐾 QwenPaw 集成
 
 用于接入阿里的 [QwenPaw](https://github.com/agentscope-ai/QwenPaw)。桥接器会调用 QwenPaw 的 HTTP Console 后台任务接口，将小爱音箱识别到的文本发送给指定 Agent，并把回复通过小爱或豆包 TTS 播放出来。
@@ -572,7 +700,7 @@ async def before_wakeup(speaker, text, source, app):
     # 返回 None → 交给小爱原生处理
 ```
 
-**返回值含义：** `"openclaw"` → OpenClaw 连续对话，`"openai"` → OpenAI 兼容服务连续对话，`"qwenpaw"` → QwenPaw 连续对话，`"xiaozhi"` → 小智 AI，`None` → 不处理（用户可自行调用 `app.send_to_openclaw()` / `app.send_to_openai()` / `app.send_to_qwenpaw()` 等方法）
+**返回值含义：** `"openclaw"` → OpenClaw 连续对话，`"openai"` → OpenAI 兼容服务连续对话，`"hermes"` → Hermes 连续对话，`"qwenpaw"` → QwenPaw 连续对话，`"xiaozhi"` → 小智 AI，`None` → 不处理（用户可自行调用 `app.send_to_openclaw()` / `app.send_to_openai()` / `app.send_to_hermes()` / `app.send_to_qwenpaw()` 等方法）
 
 ### 🧠 多 Agent 路由 — 一个唤醒词，一个专属 Agent
 

--- a/config.py
+++ b/config.py
@@ -26,11 +26,12 @@ async def before_wakeup(speaker, text, source, app):
         source  : 唤醒来源
                     'kws'    — 本地关键词唤醒（用户说了唤醒词）
                     'xiaoai' — 小爱同学收到用户语音指令
-        app     : MainApp 实例，可调用 send_to_openclaw / send_to_openai / send_to_qwenpaw 等方法
+        app     : MainApp 实例，可调用 send_to_openclaw / send_to_openai / send_to_hermes / send_to_qwenpaw 等方法
 
     返回值：
         "openclaw" — 进入 OpenClaw 连续对话流程
         "openai"   — 进入 OpenAI 兼容服务连续对话流程（例如 Hermes Agent API Server）
+        "hermes"   — 进入 Hermes Agent 连续对话流程
         "qwenpaw"  — 进入 QwenPaw 连续对话流程
         "xiaozhi"  — 进入小智 AI 流程
         None       — 不做额外处理（可在此自行调用 app.send_to_openclaw 等）
@@ -75,6 +76,10 @@ async def before_wakeup(speaker, text, source, app):
             await speaker.play(text="小黑来了")
             return "openai"
 
+        if "你好赫尔墨斯" in text:
+            await speaker.play(text="赫尔墨斯来了")
+            return "hermes"
+
         if "小爪" in text:
             await speaker.play(text="小爪来了")
             return "qwenpaw"
@@ -99,6 +104,10 @@ async def before_wakeup(speaker, text, source, app):
         if text == "召唤小黑":
             await speaker.abort_xiaoai()
             return "openai"  # OpenAI-compatible service continuous conversation
+
+        if text == "召唤赫尔墨斯":
+            await speaker.abort_xiaoai()
+            return "hermes"  # Hermes Agent continuous conversation
 
         if text == "召唤小爪":
             await speaker.abort_xiaoai()
@@ -125,6 +134,13 @@ async def before_wakeup(speaker, text, source, app):
             await app.send_to_openai_and_play_reply(text.replace("让小黑", ""))
             return None
 
+        if "让赫尔墨斯" in text:
+            await speaker.abort_xiaoai()
+            await app.send_to_hermes_and_play_reply(
+                text.replace("让赫尔墨斯", "")
+            )
+            return None
+
         if "让小爪" in text:
             await speaker.abort_xiaoai()
             await app.send_to_qwenpaw_and_play_reply(text.replace("让小爪", ""))
@@ -139,8 +155,9 @@ async def after_wakeup(speaker, source=None, session_key=None):
         - 'xiaozhi': 小智对话超时退出
         - 'openclaw': OpenClaw 连续对话退出
         - 'openai': OpenAI 兼容服务连续对话退出
+        - 'hermes': Hermes Agent 连续对话退出
         - 'qwenpaw': QwenPaw 连续对话退出
-    - session_key: 当前 OpenClaw/OpenAI/QwenPaw 后端 session_key
+    - session_key: 当前 OpenClaw/OpenAI/Hermes/QwenPaw 后端 session_key
         可据此区分是哪个 Agent 退出，例如播放不同的退出提示语
     """
     if source == "openclaw":
@@ -161,6 +178,8 @@ async def after_wakeup(speaker, source=None, session_key=None):
         await speaker.play(text="龙虾，再见")
     if source == "openai":
         await speaker.play(text="小黑，再见")
+    if source == "hermes":
+        await speaker.play(text="赫尔墨斯，再见")
     if source == "qwenpaw":
         await speaker.play(text="小爪，再见")
     if source == "xiaozhi":
@@ -177,6 +196,7 @@ APP_CONFIG = {
             "龙虾你好",
             "你好小黑",
             "小黑你好",
+            "你好赫尔墨斯",
             "你好小爪",
             "小爪你好",
         ],
@@ -326,6 +346,53 @@ APP_CONFIG = {
         "exit_keywords": ["退出", "停止", "再见"],
         "rule_prompt": "注意：将结果处理成纯文字版，不要返回任何 markdown 格式，也不要包含任何代码块，并将字数控制在300字以内",
         "rule_prompt_for_skill": "注意：这条消息是主人通过小爱音箱发送的，他看不到你回复的文字。字数控制在300字以内",
+        "extra_body": {},
+    },
+    # Hermes Agent API Server 专用配置
+    # 独立于普通 OpenAI-compatible 后端启用和管理。
+    "hermes": {
+        # Hermes API Server 地址，通常填写到 /v1；Docker 中 127.0.0.1 指向本容器。
+        "base_url": "http://127.0.0.1:8642/v1",
+        "api_key": "",
+        "model": "hermes-agent",
+        # 可选：Hermes 官方 multi-profile 路由。空值表示 default profile。
+        # Bridge 会自动构造 /p/<profile>/v1/...，不要手工写入 base_url。
+        # 命名 profile 才需要配置自己的 API key。
+        "profile": "",
+        "profile_api_keys": {},
+        # 输入模式：
+        #   - "local_asr": 使用本地 VAD + SherpaASR
+        #   - "xiaoai_asr": 接管小爱原生 ASR 结果
+        "input_mode": "local_asr",
+        "session_key": "agent:default:open-xiaoai-bridge",
+        "session_header": "X-Hermes-Session-Key",
+        "system_prompt": "",
+        "temperature": 0.7,
+        "max_tokens": 512,
+        "history_max_messages": 20,
+        "response_timeout": 120,
+        # 显式选择回答交付模式：streaming（默认）或 complete。
+        "response_mode": "streaming",
+        # streaming 模式的分句参数。
+        "streaming": {
+            "sentence_min_chars": 24,
+            "sentence_max_chars": 160,
+        },
+        # 短任务不播报；长任务最多播报两次自然语言进度。
+        "progress": {
+            "enabled": True,
+            "initial_delay": 8,
+            "min_interval": 20,
+            "max_messages": 2,
+        },
+        "tts_speed": 1.0,
+        "tts_speaker": "xiaoai",
+        "session_tts_speakers": {},
+        "exit_keywords": ["退出", "停止", "再见"],
+        # 可选：为自动播放/连续对话追加通用规则；默认留空。
+        "rule_prompt": "",
+        # 可选：为 fire-and-forget / skill 场景追加通用规则；默认留空。
+        "rule_prompt_for_skill": "",
         "extra_body": {},
     },
     # QwenPaw Configuration

--- a/core/app.py
+++ b/core/app.py
@@ -5,6 +5,7 @@ This module manages the main application flow, coordinating between:
 - XiaoZhi (AI conversation service)
 - OpenClaw (External integration)
 - OpenAI (OpenAI-compatible chat service)
+- Hermes（Hermes Agent API 服务）
 - QwenPaw (QwenPaw personal agent workstation)
 - Audio system (VAD, KWS, Codec)
 """
@@ -25,6 +26,7 @@ from core.services.protocols.typing import (
 )
 from core.openclaw import OpenClawManager
 from core.openai import OpenAIManager
+from core.hermes import HermesManager
 from core.qwenpaw import QwenPawManager
 from core.services.api_server import APIServer
 
@@ -41,13 +43,16 @@ class MainApp:
         enable_openclaw: bool = False,
         enable_openai: bool = False,
         enable_qwenpaw: bool = False,
+        enable_hermes: bool = False,
     ):
         """Get singleton instance.
 
         Args:
             enable_xiaozhi: Whether to enable XiaoZhi AI connection (default: True)
             enable_openclaw: Whether to enable OpenClaw connection (default: False)
+            enable_openai: 是否启用 OpenAI 连接（默认 False）
             enable_qwenpaw: Whether to enable QwenPaw connection (default: False)
+            enable_hermes: 是否启用 Hermes 连接（默认 False）
         """
         if cls._instance is None:
             cls._instance = MainApp(
@@ -55,6 +60,7 @@ class MainApp:
                 enable_openclaw=enable_openclaw,
                 enable_openai=enable_openai,
                 enable_qwenpaw=enable_qwenpaw,
+                enable_hermes=enable_hermes,
             )
         return cls._instance
 
@@ -64,13 +70,16 @@ class MainApp:
         enable_openclaw: bool = False,
         enable_openai: bool = False,
         enable_qwenpaw: bool = False,
+        enable_hermes: bool = False,
     ):
         """Initialize the main application.
 
         Args:
             enable_xiaozhi: Whether to enable XiaoZhi AI connection
             enable_openclaw: Whether to enable OpenClaw connection
+            enable_openai: 是否启用 OpenAI 连接
             enable_qwenpaw: Whether to enable QwenPaw connection
+            enable_hermes: 是否启用 Hermes 连接
         """
         if MainApp._instance is not None:
             raise Exception("MainApp is singleton, use instance() to get instance")
@@ -84,6 +93,7 @@ class MainApp:
         self._enable_openclaw = enable_openclaw
         self._enable_openai = enable_openai
         self._enable_qwenpaw = enable_qwenpaw
+        self._enable_hermes = enable_hermes
 
         # Device state
         self.device_state = DeviceState.IDLE
@@ -157,6 +167,12 @@ class MainApp:
             ):
                 local_asr_backends.append("OpenAI")
             if (
+                self._enable_hermes
+                and self.config.get_app_config("hermes.input_mode", "local_asr")
+                == "local_asr"
+            ):
+                local_asr_backends.append("Hermes")
+            if (
                 self._enable_qwenpaw
                 and self.config.get_app_config("qwenpaw.input_mode", "local_asr")
                 == "local_asr"
@@ -197,6 +213,9 @@ class MainApp:
         if self._enable_openai:
             OpenAIManager.initialize_from_config()
             asyncio.run_coroutine_threadsafe(OpenAIManager.connect(), self.loop)
+        if self._enable_hermes:
+            HermesManager.initialize_from_config()
+            asyncio.run_coroutine_threadsafe(HermesManager.connect(), self.loop)
         if self._enable_qwenpaw:
             QwenPawManager.initialize_from_config()
             asyncio.run_coroutine_threadsafe(QwenPawManager.connect(), self.loop)
@@ -218,6 +237,7 @@ class MainApp:
             self._enable_xiaozhi
             or self._enable_openclaw
             or self._enable_openai
+            or self._enable_hermes
             or self._enable_qwenpaw
         ):
             # Check audio input via env var (same as Rust), default True
@@ -245,6 +265,13 @@ class MainApp:
                     self._enable_openai
                     and self.config.get_app_config(
                         "openai.input_mode", "local_asr"
+                    )
+                    == "local_asr"
+                )
+                or (
+                    self._enable_hermes
+                    and self.config.get_app_config(
+                        "hermes.input_mode", "local_asr"
                     )
                     == "local_asr"
                 )
@@ -386,6 +413,10 @@ class MainApp:
             asyncio.run_coroutine_threadsafe(
                 OpenAIManager.close(), self.loop
             )
+        if self._enable_hermes and HermesManager.is_enabled():
+            asyncio.run_coroutine_threadsafe(
+                HermesManager.close(), self.loop
+            )
         if QwenPawManager.is_enabled():
             asyncio.run_coroutine_threadsafe(
                 QwenPawManager.close(), self.loop
@@ -482,6 +513,64 @@ class MainApp:
     def set_openai_session_key(self, session_key: str):
         """Override the OpenAI-compatible service session key at runtime."""
         OpenAIManager.set_session_key(session_key)
+
+    async def send_to_hermes(
+        self,
+        text: str,
+        wait_response: bool = False,
+    ) -> str | None:
+        """向 Hermes Agent 发送消息。"""
+        try:
+            full_text = text
+            if HermesManager._rule_prompt_for_skill:
+                full_text = text + "\n" + HermesManager._rule_prompt_for_skill
+            return await HermesManager.send(
+                full_text,
+                wait_response=wait_response,
+            )
+        except Exception as exc:
+            logger.error(
+                f"[MainApp] 发送消息到 Hermes 失败: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            return None
+
+    async def send_to_hermes_and_play_reply(
+        self,
+        text: str,
+        wait_response: bool = False,
+    ) -> str | None:
+        """向 Hermes Agent 发送消息并播放回复。"""
+        try:
+            full_text = text
+            if HermesManager._rule_prompt:
+                full_text = text + "\n" + HermesManager._rule_prompt
+            return await HermesManager.send_and_play_reply(
+                full_text,
+                wait_response=wait_response,
+            )
+        except Exception as exc:
+            logger.error(
+                f"[MainApp] 发送消息到 Hermes 失败: "
+                f"{type(exc).__name__}: {exc}"
+            )
+            return None
+
+    def set_hermes_session_key(self, session_key: str):
+        """覆盖 Hermes 长期记忆使用的 Session Key。"""
+        HermesManager.set_session_key(session_key)
+
+    def reset_hermes_session(self, session_key: str | None = None):
+        """清理 Hermes Bridge 历史与对应的原生 Session-Id。"""
+        HermesManager.reset_session(session_key)
+
+    def get_hermes_session_state(self) -> dict:
+        """读取当前 Hermes profile/session 的非敏感状态。"""
+        return HermesManager.get_session_state()
+
+    def set_hermes_profile(self, profile: str | None):
+        """通过 Hermes 官方 /p/<profile>/ 路由切换 Profile。"""
+        HermesManager.set_profile(profile)
 
     async def send_to_qwenpaw(self, text: str, wait_response: bool = False) -> str | None:
         """Send message to QwenPaw."""

--- a/core/external_conversation.py
+++ b/core/external_conversation.py
@@ -236,22 +236,19 @@ class ExternalConversationController:
                 logger.info(f"Exit keyword: {kw}", module=self.LOG_MODULE)
                 return "exit"
 
-        # 4. Send to backend and wait for response
-        full_text = text
-        if self.backend._rule_prompt:
-            full_text = text + "\n" + self.backend._rule_prompt
-        # 先发出请求（不阻塞等回复），立即播"咻"给用户即时反馈，再等回复
-        # 注意：直接用 _send_and_track 而非 send(wait_response=False)，
-        # 后者会立即清掉 Future，导致后续 _wait_response 拿不到回复
-        run_id = await self.backend._send_and_track(full_text)
-        await self._play_send_sound()
-        response = await self.backend._wait_response(run_id) if run_id else None
+        # 4. 发送到后端并等待回复；支持流式的子类可覆盖这个钩子，
+        #    不改变现有稳定后端的默认路径。
+        response, already_played = await self._request_backend_turn(
+            text,
+            play_send_sound=True,
+        )
         if response is None:
             logger.warning(f"No response from {self.BACKEND_NAME}", module=self.LOG_MODULE)
-            speaker = get_speaker()
-            if speaker:
-                await speaker.play(text="抱歉，我没有收到回复")
-            return "continue"
+            if not already_played:
+                speaker = get_speaker()
+                if speaker:
+                    await speaker.play(text="抱歉，我没有收到回复")
+                return "continue"
 
         # 5. Stop recording → TTS → Notify → Start recording → Wait for silence
         #    Mic is off during TTS and notify, so no echo is captured.
@@ -259,8 +256,9 @@ class ExternalConversationController:
         #    enough for TTS echo to fade. After starting recording, we wait
         #    for silence to ensure any residual echo or buffered audio clears.
         #    VAD.resume() resets all state, so speech detection starts clean.
-        await self._stop_recording()
-        await self._play_tts(str(response))
+        if not already_played:
+            await self._stop_recording()
+            await self._play_tts(str(response))
         await self._play_notify()
         await self._start_recording()
         logger.debug("Recording started, waiting for silence...", module=self.LOG_MODULE)
@@ -281,23 +279,59 @@ class ExternalConversationController:
                 logger.info(f"Exit keyword: {kw}", module=self.LOG_MODULE)
                 return "exit"
 
-        full_text = text
-        if self.backend._rule_prompt:
-            full_text = text + "\n" + self.backend._rule_prompt
-        response = await self.backend.send(full_text, wait_response=True)
+        response, already_played = await self._request_backend_turn(
+            text,
+            play_send_sound=False,
+        )
         if response is None:
             logger.warning(f"No response from {self.BACKEND_NAME}", module=self.LOG_MODULE)
-            speaker = get_speaker()
-            if speaker:
-                await speaker.play(text="抱歉，我没有收到回复")
-            return "continue"
+            if not already_played:
+                speaker = get_speaker()
+                if speaker:
+                    await speaker.play(text="抱歉，我没有收到回复")
+                return "continue"
 
-        await self._stop_recording()
-        await self._play_tts(str(response))
+        if not already_played:
+            await self._stop_recording()
+            await self._play_tts(str(response))
         await self._play_notify()
         await self._start_recording()
         logger.debug("Ready for next XiaoAI native ASR round", module=self.LOG_MODULE)
         return "continue"
+
+    async def _request_backend_turn(
+        self,
+        text: str,
+        *,
+        play_send_sound: bool,
+    ) -> tuple[str | None, bool]:
+        """请求一轮后端对话，同时保持原有非流式行为。
+
+        返回 ``(response, already_played)``。流式后端可以覆盖该方法，在
+        完整回复到达前提前交付语音。
+        """
+
+        full_text = text
+        if self.backend._rule_prompt:
+            full_text = text + "\n" + self.backend._rule_prompt
+
+        if play_send_sound:
+            # 本地 ASR 先发出请求（不阻塞等回复），再播放发送提示音。
+            # 直接使用 _send_and_track，避免后台 waiter 抢先清理 Future。
+            run_id = await self.backend._send_and_track(full_text)
+            await self._play_send_sound()
+            response = (
+                await self.backend._wait_response(run_id)
+                if run_id
+                else None
+            )
+        else:
+            # XiaoAI ASR 保持原有 send(wait_response=True) 清理语义。
+            response = await self.backend.send(
+                full_text,
+                wait_response=True,
+            )
+        return response, False
 
     # ---- VAD integration ----
 

--- a/core/hermes.py
+++ b/core/hermes.py
@@ -1,0 +1,599 @@
+"""基于 OpenAI-compatible 传输的 Hermes Agent 专用后端。"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Awaitable, Callable
+import inspect
+import re
+from typing import Any
+
+import aiohttp
+import open_xiaoai_server
+
+from core.hermes_progress import HermesToolProgress
+from core.openai import OpenAIManager
+from core.openai_stream import stream_openai_chat_completion
+from core.utils.base import get_env
+from core.utils.config import ConfigManager
+from core.utils.logger import logger
+
+
+class HermesManager(OpenAIManager):
+    """使用独立配置与会话状态的 Hermes 专用后端。"""
+
+    CONFIG_PREFIX = "hermes"
+    ENV_ENABLE = "HERMES_ENABLE"
+    LOG_NAME = "Hermes"
+    DEFAULT_BASE_URL = "http://127.0.0.1:8642/v1"
+    DEFAULT_MODEL = "hermes-agent"
+    DEFAULT_SESSION_KEY = "agent:default:open-xiaoai-bridge"
+    DEFAULT_SESSION_HEADER = "X-Hermes-Session-Key"
+    DEFAULT_RESPONSE_MODE = "streaming"
+    RESPONSE_MODES = frozenset({"streaming", "complete"})
+    CAPABILITIES_TIMEOUT = 2.0
+    _PROFILE_RE = re.compile(r"^[a-z0-9][a-z0-9_-]{0,63}$")
+    SESSION_ID_HEADER = "X-Hermes-Session-Id"
+
+    # Hermes 和普通 OpenAI 可同时启用，因此可变运行状态必须由子类独立持有。
+    _initialized = False
+    _reload_listener_registered = False
+    _enabled = False
+    _base_url = DEFAULT_BASE_URL
+    _api_key = ""
+    _model = DEFAULT_MODEL
+    _session_key = DEFAULT_SESSION_KEY
+    _session_header = DEFAULT_SESSION_HEADER
+    _system_prompt = ""
+    _temperature = None
+    _max_tokens = None
+    _timeout = 120
+    _history_max_messages = 20
+    _extra_body: dict[str, Any] = {}
+    _tts_speaker = None
+    _session_tts_speakers: dict[str, str] = {}
+    _tts_speed = 1.0
+    _rule_prompt = ""
+    _rule_prompt_for_skill = ""
+    _response_mode = DEFAULT_RESPONSE_MODE
+    _profile = ""
+    _profile_api_keys: dict[str, str] = {}
+    _sessions: dict[str, list[dict[str, str]]] = {}
+    _hermes_session_ids: dict[str, str] = {}
+    _capabilities_checked = False
+    _capabilities: dict[str, Any] | None = None
+    _capabilities_diagnostic: str | None = None
+    _response_events: dict[str, asyncio.Future] = {}
+    _response_texts: dict[str, str] = {}
+    _response_tts_speakers: dict[str, str | None] = {}
+    last_error: str | None = None
+
+    @classmethod
+    def initialize_from_config(cls, enabled: bool | None = None):
+        logger.info("[Hermes] Initializing from config...")
+        cls.reload_from_config(enabled=enabled)
+        cls._initialized = True
+
+    @classmethod
+    def reload_from_config(cls, enabled: bool | None = None):
+        """刷新 Hermes 配置，不触碰普通 OpenAI 的状态。"""
+
+        config_manager = ConfigManager.instance()
+        if not cls._reload_listener_registered:
+            config_manager.add_reload_listener(
+                lambda _old, _new: cls.reload_from_config()
+            )
+            cls._reload_listener_registered = True
+
+        config = config_manager.get_app_config(cls.CONFIG_PREFIX, {})
+        if enabled is not None:
+            cls._enabled = enabled
+        else:
+            env_enabled = get_env(cls.ENV_ENABLE)
+            cls._enabled = (
+                env_enabled.lower() in ("1", "true", "yes")
+                if env_enabled is not None
+                else False
+            )
+
+        cls._base_url = str(
+            config.get("base_url", cls.DEFAULT_BASE_URL)
+        ).rstrip("/")
+        cls._api_key = str(config.get("api_key", "") or "")
+        cls._model = str(config.get("model", cls.DEFAULT_MODEL))
+        cls._session_key = str(
+            config.get("session_key", cls.DEFAULT_SESSION_KEY)
+        )
+        cls._session_header = str(
+            config.get("session_header", cls.DEFAULT_SESSION_HEADER) or ""
+        ).strip()
+        cls._system_prompt = str(config.get("system_prompt", "") or "")
+        cls._timeout = int(config.get("response_timeout", 120))
+        cls._history_max_messages = max(
+            0,
+            int(config.get("history_max_messages", 20)),
+        )
+        cls._temperature = cls._optional_float(config.get("temperature"))
+        cls._max_tokens = cls._optional_int(config.get("max_tokens"))
+        cls._extra_body = config.get("extra_body", {})
+        if not isinstance(cls._extra_body, dict):
+            cls._extra_body = {}
+        cls._tts_speaker = config.get("tts_speaker", None)
+        cls._session_tts_speakers = (
+            {
+                str(key): str(value)
+                for key, value in config.get(
+                    "session_tts_speakers",
+                    {},
+                ).items()
+                if key and value
+            }
+            if isinstance(config.get("session_tts_speakers", {}), dict)
+            else {}
+        )
+        cls._tts_speed = float(config.get("tts_speed", 1.0))
+        cls._rule_prompt = str(config.get("rule_prompt", "") or "")
+        cls._rule_prompt_for_skill = str(
+            config.get("rule_prompt_for_skill", "") or ""
+        )
+        response_mode = str(
+            config.get("response_mode", cls.DEFAULT_RESPONSE_MODE) or ""
+        ).strip().lower()
+        if response_mode not in cls.RESPONSE_MODES:
+            logger.warning(
+                f"[Hermes] Unknown response_mode={response_mode!r}; "
+                f"using {cls.DEFAULT_RESPONSE_MODE!r}"
+            )
+            response_mode = cls.DEFAULT_RESPONSE_MODE
+        cls._response_mode = response_mode
+        cls._profile_api_keys = (
+            {
+                str(key): str(value)
+                for key, value in config.get("profile_api_keys", {}).items()
+                if key and value
+            }
+            if isinstance(config.get("profile_api_keys", {}), dict)
+            else {}
+        )
+        configured_profile = str(config.get("profile", "") or "").strip()
+        cls._profile = cls._validate_profile(configured_profile)
+
+        if cls._enabled:
+            logger.info(
+                f"[Hermes] Enabled, base_url={cls._base_url}, "
+                f"model={cls._model}, response_mode={cls._response_mode}"
+            )
+
+    @classmethod
+    def get_response_mode(cls) -> str:
+        """Return the explicit final-response delivery mode."""
+
+        return cls._response_mode
+
+    @classmethod
+    def set_session_key(cls, session_key: str):
+        logger.info(
+            f"[Hermes] Session key updated: "
+            f"{cls._session_key!r} -> {session_key!r}"
+        )
+        cls._session_key = session_key
+
+    @classmethod
+    def get_session_key(cls) -> str:
+        """Return the active Hermes long-term-memory scope key."""
+
+        return cls._session_key
+
+    @classmethod
+    def set_profile(cls, profile: str | None):
+        """Route subsequent requests through Hermes' native profile prefix."""
+
+        normalized = cls._validate_profile(profile)
+        if normalized and normalized != "default":
+            if normalized not in cls._profile_api_keys:
+                raise ValueError(
+                    f"No API key configured for Hermes profile {normalized!r}"
+                )
+        logger.info(
+            f"Hermes profile updated: {cls.get_profile()!r} -> "
+            f"{normalized or 'default'!r}",
+            module="Hermes",
+        )
+        cls._profile = normalized
+
+    @classmethod
+    def get_profile(cls) -> str:
+        return cls._profile or "default"
+
+    @classmethod
+    def get_session_state(cls) -> dict[str, Any]:
+        """Return lightweight, non-secret state for the active profile/session."""
+
+        scope_key = cls._conversation_scope_key()
+        return {
+            "profile": cls.get_profile(),
+            "session_key": cls._session_key,
+            "session_id": cls._hermes_session_ids.get(scope_key),
+            "history_messages": len(cls._sessions.get(scope_key, [])),
+        }
+
+    @classmethod
+    def reset_session(cls, session_key: str | None = None):
+        """Discard both Bridge text history and Hermes' native transcript."""
+
+        target_session_key = session_key or cls._session_key
+        scope_key = cls._conversation_scope_key(target_session_key)
+        cls._sessions.pop(scope_key, None)
+        cls._hermes_session_ids.pop(scope_key, None)
+
+    @classmethod
+    def _validate_profile(cls, profile: str | None) -> str:
+        normalized = str(profile or "").strip()
+        if not normalized or normalized == "default":
+            return ""
+        if not cls._PROFILE_RE.fullmatch(normalized):
+            raise ValueError(
+                "Hermes profile must match "
+                "^[a-z0-9][a-z0-9_-]{0,63}$"
+            )
+        return normalized
+
+    @classmethod
+    def _conversation_scope_key(
+        cls,
+        session_key: str | None = None,
+    ) -> str:
+        return f"{cls.get_profile()}\x1f{session_key or cls._session_key}"
+
+    @classmethod
+    def _capture_response_headers(
+        cls,
+        headers,
+        *,
+        session_key: str,
+    ):
+        session_id = str(
+            headers.get(cls.SESSION_ID_HEADER, "") or ""
+        ).strip()
+        if not session_id:
+            return
+        cls._hermes_session_ids[session_key] = session_id
+        logger.debug(
+            f"Captured native session id for {session_key!r}",
+            module="Hermes",
+        )
+
+    @classmethod
+    def _headers(cls) -> dict[str, str]:
+        headers = {"Content-Type": "application/json"}
+        api_key = (
+            cls._profile_api_keys.get(cls._profile, "")
+            if cls._profile
+            else cls._api_key
+        )
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        if cls._session_header and cls._session_key:
+            headers[cls._session_header] = cls._session_key
+        session_id = cls._hermes_session_ids.get(
+            cls._conversation_scope_key()
+        )
+        if session_id:
+            headers[cls.SESSION_ID_HEADER] = session_id
+        return headers
+
+    @classmethod
+    def _profiled_base_url(cls) -> str:
+        if not cls._profile:
+            return cls._base_url
+
+        marker = "/v1"
+        marker_index = cls._base_url.find(marker)
+        if marker_index < 0:
+            return (
+                cls._base_url.rstrip("/")
+                + f"/p/{cls._profile}/v1"
+            )
+
+        prefix = cls._base_url[:marker_index].rstrip("/")
+        suffix = cls._base_url[marker_index:]
+        profile_marker = re.search(r"/p/[a-z0-9][a-z0-9_-]{0,63}$", prefix)
+        if profile_marker:
+            prefix = prefix[:profile_marker.start()]
+        return f"{prefix}/p/{cls._profile}{suffix}"
+
+    @classmethod
+    def _chat_completions_url(cls) -> str:
+        base_url = cls._profiled_base_url()
+        if base_url.endswith("/chat/completions"):
+            return base_url
+        return base_url.rstrip("/") + "/chat/completions"
+
+    @classmethod
+    def _capabilities_url(cls) -> str:
+        base_url = cls._profiled_base_url().rstrip("/")
+        if base_url.endswith("/chat/completions"):
+            base_url = base_url.removesuffix("/chat/completions")
+        if base_url.endswith("/v1"):
+            return base_url + "/capabilities"
+        return base_url + "/v1/capabilities"
+
+    @classmethod
+    async def connect(cls) -> bool:
+        """Probe Hermes metadata once without making startup depend on it."""
+
+        if not cls._initialized:
+            cls.initialize_from_config()
+        if not cls._enabled:
+            return False
+        await cls._probe_capabilities_once()
+        return True
+
+    @classmethod
+    async def _probe_capabilities_once(cls) -> dict[str, Any] | None:
+        if cls._capabilities_checked:
+            return cls._capabilities
+        cls._capabilities_checked = True
+
+        headers = {
+            key: value
+            for key, value in cls._headers().items()
+            if key == "Authorization"
+        }
+        try:
+            timeout = aiohttp.ClientTimeout(total=cls.CAPABILITIES_TIMEOUT)
+            async with aiohttp.ClientSession(timeout=timeout) as session:
+                async with session.get(
+                    cls._capabilities_url(),
+                    headers=headers,
+                ) as response:
+                    if response.status == 404:
+                        cls._capabilities_diagnostic = "unsupported (HTTP 404)"
+                        logger.info(
+                            "Capabilities endpoint is unavailable; continuing "
+                            "with Chat Completions",
+                            module="Hermes",
+                        )
+                        return None
+                    if response.status >= 400:
+                        cls._capabilities_diagnostic = (
+                            f"HTTP {response.status}"
+                        )
+                        logger.warning(
+                            "Capabilities probe failed with "
+                            f"HTTP {response.status}; continuing with Chat Completions",
+                            module="Hermes",
+                        )
+                        return None
+                    body = await response.json(content_type=None)
+        except asyncio.TimeoutError:
+            cls._capabilities_diagnostic = "timeout"
+            logger.warning(
+                "Capabilities probe timed out; continuing with Chat Completions",
+                module="Hermes",
+            )
+            return None
+        except Exception as exc:
+            cls._capabilities_diagnostic = type(exc).__name__
+            logger.warning(
+                "Capabilities probe failed; continuing with Chat Completions: "
+                f"{type(exc).__name__}: {exc}",
+                module="Hermes",
+            )
+            return None
+
+        if not isinstance(body, dict) or (
+            body.get("object") != "hermes.api_server.capabilities"
+            or body.get("platform") != "hermes-agent"
+        ):
+            cls._capabilities_diagnostic = "malformed response"
+            logger.warning(
+                "Capabilities response is not a Hermes API capability object; "
+                "continuing with Chat Completions",
+                module="Hermes",
+            )
+            return None
+
+        cls._capabilities = body
+        cls._capabilities_diagnostic = "available"
+        endpoints = body.get("endpoints", {})
+        surfaces = sorted(endpoints) if isinstance(endpoints, dict) else []
+        logger.info(
+            "Hermes-aware endpoint detected; available surfaces: "
+            + (", ".join(surfaces) if surfaces else "not advertised"),
+            module="Hermes",
+        )
+        return body
+
+    @classmethod
+    def get_capabilities(cls) -> dict[str, Any] | None:
+        """Return discovered capabilities without triggering another request."""
+
+        return dict(cls._capabilities) if cls._capabilities else None
+
+    @classmethod
+    async def _request_chat_completion(cls, text: str) -> str | None:
+        """Send a non-streaming turn while retaining Hermes session state."""
+
+        session_key = cls._session_key
+        scope_key = cls._conversation_scope_key(session_key)
+        history = cls._sessions.setdefault(scope_key, [])
+        payload: dict[str, Any] = {
+            "model": cls._model,
+            "messages": cls._build_messages(history, text),
+            "stream": False,
+            **cls._extra_body,
+        }
+        if cls._temperature is not None:
+            payload["temperature"] = cls._temperature
+        if cls._max_tokens is not None:
+            payload["max_tokens"] = cls._max_tokens
+
+        async with aiohttp.ClientSession(
+            timeout=aiohttp.ClientTimeout(total=cls._timeout)
+        ) as session:
+            async with session.post(
+                cls._chat_completions_url(),
+                json=payload,
+                headers=cls._headers(),
+            ) as response:
+                body = await response.json(content_type=None)
+                if response.status >= 400:
+                    message = (
+                        body.get("error", body)
+                        if isinstance(body, dict)
+                        else body
+                    )
+                    raise RuntimeError(
+                        f"HTTP {response.status}: {message}"
+                    )
+                cls._capture_response_headers(
+                    response.headers,
+                    session_key=scope_key,
+                )
+
+        response_text = cls._extract_response_text(body)
+        if response_text:
+            cls._append_history(history, text, response_text)
+        return response_text
+
+    @classmethod
+    async def request_streaming_chat_completion(
+        cls,
+        text: str,
+        *,
+        on_delta: Callable[[str], Awaitable[None] | None],
+        on_tool_progress: (
+            Callable[[HermesToolProgress], Awaitable[None] | None]
+            | None
+        ) = None,
+    ) -> str:
+        """流式接收标准文本和 Hermes 工具生命周期事件。"""
+
+        async def on_event(event):
+            if event.event != "hermes.tool.progress":
+                logger.debug(
+                    f"Ignoring unsupported SSE event: {event.event}",
+                    module="Hermes",
+                )
+                return
+            try:
+                progress = HermesToolProgress.from_json(event.data)
+            except Exception as exc:
+                logger.debug(
+                    f"Ignoring malformed tool progress event: {exc}",
+                    module="Hermes",
+                )
+                return
+            if not progress:
+                return
+            logger.debug(
+                f"Tool progress event: {progress.technical_log()}",
+                module="Hermes",
+            )
+            if on_tool_progress:
+                result = on_tool_progress(progress)
+                if inspect.isawaitable(result):
+                    await result
+
+        return await stream_openai_chat_completion(
+            cls,
+            text,
+            on_delta=on_delta,
+            on_event=on_event,
+            log_name="Hermes",
+        )
+
+    @classmethod
+    async def _play_response_with_tts(
+        cls,
+        text: str,
+        tts_speaker: str | None = None,
+        playback_token: int | None = None,
+    ) -> bool:
+        """通过项目标准 Speaker/TTS 路径播放 Hermes 回复。"""
+
+        from core.ref import get_speaker
+
+        try:
+            resolved_tts_speaker = (
+                tts_speaker
+                or cls.get_tts_speaker_for_session_key()
+            )
+            if resolved_tts_speaker == cls.XIAOAI_TTS_SPEAKER:
+                speaker = get_speaker()
+                if not speaker:
+                    logger.error(
+                        "Speaker not available for native TTS",
+                        module="Hermes",
+                    )
+                    return False
+                return bool(await speaker.play(text=text, blocking=True))
+
+            from core.services.tts.doubao import DoubaoTTS
+
+            tts_config = ConfigManager.instance().get_app_config(
+                "tts.doubao",
+                {},
+            )
+            app_id = tts_config.get("app_id")
+            access_key = tts_config.get("access_key")
+            if not app_id or not access_key:
+                logger.warning(
+                    "Doubao TTS credentials not configured; "
+                    "using native XiaoAI TTS",
+                    module="Hermes",
+                )
+                speaker = get_speaker()
+                return (
+                    bool(await speaker.play(text=text, blocking=True))
+                    if speaker
+                    else False
+                )
+
+            speaker_id = resolved_tts_speaker or tts_config.get(
+                "default_speaker",
+                "zh_female_xiaohe_uranus_bigtts",
+            )
+            tts = DoubaoTTS(
+                app_id=app_id,
+                access_key=access_key,
+                speaker=speaker_id,
+            )
+            resolved_format = tts.resolve_audio_format(text)
+            if tts_config.get("stream", False):
+                await open_xiaoai_server.tts_stream_play(
+                    text,
+                    app_id=app_id,
+                    access_key=access_key,
+                    resource_id=tts.resource_id,
+                    speaker=speaker_id,
+                    speed=cls._tts_speed,
+                    format=resolved_format,
+                    sample_rate=24000,
+                    playback_token=playback_token,
+                )
+            else:
+                await open_xiaoai_server.tts_play(
+                    text,
+                    app_id=app_id,
+                    access_key=access_key,
+                    resource_id=tts.resource_id,
+                    speaker=speaker_id,
+                    speed=cls._tts_speed,
+                    format=resolved_format,
+                    sample_rate=24000,
+                    playback_token=playback_token,
+                )
+            return True
+        except Exception as exc:
+            logger.error(
+                f"TTS playback failed: {type(exc).__name__}: {exc}",
+                module="Hermes",
+            )
+            speaker = get_speaker()
+            return (
+                bool(await speaker.play(text=text, blocking=True))
+                if speaker
+                else False
+            )

--- a/core/hermes_conversation.py
+++ b/core/hermes_conversation.py
@@ -1,0 +1,125 @@
+"""Hermes Agent 连续对话控制器。"""
+
+import asyncio
+
+import open_xiaoai_server
+
+from core.hermes import HermesManager
+from core.hermes_progress import HermesProgressNarrator
+from core.streaming_conversation import StreamingConversationController
+from core.utils.logger import logger
+
+
+class HermesConversationController(StreamingConversationController):
+    """支持结构化进度和流式最终语音的 Hermes 会话。"""
+
+    CONFIG_PREFIX = "hermes"
+    BACKEND_NAME = "Hermes"
+    LOG_MODULE = "Hermes Conv"
+    WAKEUP_SOURCE = "hermes"
+    MANAGER = HermesManager
+    STREAMING_DEFAULT = True
+
+    def stop(self):
+        """停止连续对话，并取消 complete 模式正在等待的 HTTP 请求。"""
+
+        request_task = getattr(self, "_complete_request_task", None)
+        super().stop()
+        if request_task and not request_task.done():
+            request_task.get_loop().call_soon_threadsafe(
+                request_task.cancel
+            )
+
+    def _streaming_enabled(self) -> bool:
+        """response_mode 是唯一的响应交付模式选择。"""
+
+        return self.backend.get_response_mode() == "streaming"
+
+    async def _request_backend_turn(
+        self,
+        text: str,
+        *,
+        play_send_sound: bool,
+    ) -> tuple[str | None, bool]:
+        if self._streaming_enabled():
+            return await self._request_streaming_turn(
+                text,
+                play_send_sound=play_send_sound,
+            )
+        return await self._request_complete_turn(
+            text,
+            play_send_sound=play_send_sound,
+        )
+
+    async def _request_complete_turn(
+        self,
+        text: str,
+        *,
+        play_send_sound: bool,
+    ) -> tuple[str | None, bool]:
+        """发起一次明确的 non-streaming 请求并返回完整正文。"""
+
+        prompt = text
+        if self.backend._rule_prompt:
+            prompt = text + "\n" + self.backend._rule_prompt
+
+        request_task = asyncio.create_task(
+            self.backend._request_chat_completion(prompt)
+        )
+        self._complete_request_task = request_task
+        try:
+            if play_send_sound:
+                await self._play_send_sound()
+            return await request_task, False
+        except BaseException:
+            if not request_task.done():
+                request_task.cancel()
+            await asyncio.gather(request_task, return_exceptions=True)
+            raise
+        finally:
+            if (
+                getattr(self, "_complete_request_task", None)
+                is request_task
+            ):
+                self._complete_request_task = None
+
+    def _progress_config(self):
+        value = self._cfg("progress", {})
+        return value if isinstance(value, dict) else {}
+
+    def _create_progress_narrator(self, text: str):
+        return HermesProgressNarrator(text)
+
+    async def _request_stream(
+        self,
+        prompt: str,
+        *,
+        on_delta,
+        on_progress,
+    ) -> str | None:
+        return await self.backend.request_streaming_chat_completion(
+            prompt,
+            on_delta=on_delta,
+            on_tool_progress=on_progress,
+        )
+
+    async def _play_tts(self, text: str):
+        """播放一条排队中的 Hermes 语音，失败时不静默吞掉异常。"""
+
+        self._playback_token = open_xiaoai_server.begin_playback_session()
+        try:
+            played = await self.backend._play_response_with_tts(
+                text,
+                tts_speaker=self.backend.get_tts_speaker_for_session_key(),
+                playback_token=self._playback_token,
+            )
+            if not played:
+                raise RuntimeError("Hermes TTS playback did not complete")
+        except Exception as exc:
+            logger.error(
+                f"TTS playback error: {type(exc).__name__}: {exc}",
+                module=self.LOG_MODULE,
+            )
+            raise
+        finally:
+            self._playback_token = None

--- a/core/hermes_progress.py
+++ b/core/hermes_progress.py
@@ -1,0 +1,183 @@
+"""将 Hermes 工具生命周期事件安全转换为可播报进度。"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+import json
+import re
+
+
+_URL_RE = re.compile(r"https?://\S+", re.IGNORECASE)
+_SECRET_RE = re.compile(
+    r"(?i)\b(api[_-]?key|token|authorization|secret|password)"
+    r"\b\s*[:=]\s*\S+"
+)
+
+
+@dataclass(frozen=True)
+class HermesToolProgress:
+    """Hermes Chat Completions 发出的结构化工具生命周期事件。"""
+
+    tool: str
+    status: str
+    tool_call_id: str
+    label: str = ""
+    emoji: str = ""
+
+    @classmethod
+    def from_json(cls, data: str) -> "HermesToolProgress | None":
+        body = json.loads(data)
+        if not isinstance(body, dict):
+            return None
+        tool = str(body.get("tool") or "").strip()
+        status = str(body.get("status") or "").strip().lower()
+        tool_call_id = str(body.get("toolCallId") or "").strip()
+        if not tool or status not in {
+            "running",
+            "completed",
+            "failed",
+        }:
+            return None
+        return cls(
+            tool=tool,
+            status=status,
+            tool_call_id=tool_call_id,
+            label=str(body.get("label") or "").strip(),
+            emoji=str(body.get("emoji") or "").strip(),
+        )
+
+    def technical_log(self) -> dict[str, str]:
+        """返回已脱敏的生命周期字段，供技术日志使用。"""
+
+        return {
+            "tool": self.tool,
+            "status": self.status,
+            "tool_call_id": self.tool_call_id,
+            "label": self._safe_log_label(self.label),
+            "emoji": self.emoji,
+        }
+
+    @staticmethod
+    def _safe_log_label(label: str) -> str:
+        redacted = _URL_RE.sub("[URL]", str(label or ""))
+        redacted = _SECRET_RE.sub(
+            r"\1=[REDACTED]",
+            redacted,
+        )
+        return redacted[:500]
+
+
+# 与 Hermes agent/display.py 中 curated built-in _TOOL_VERBS 对应。
+# 这里只提供适合 TTS 的中文短句；custom/plugin/MCP 一律使用通用提示，
+# 并且绝不读取 argument preview 或 label，避免朗读机器参数和敏感内容。
+HERMES_TOOL_VOICE_STATUS = {
+    "web_search": "正在查找相关资料",
+    "web_extract": "正在读取相关内容",
+    "browser_navigate": "正在浏览相关页面",
+    "browser_click": "正在处理网页操作",
+    "browser_type": "正在处理网页内容",
+    "read_file": "正在读取文件",
+    "write_file": "正在处理文件",
+    "patch": "正在修改内容",
+    "search_files": "正在查找文件",
+    "terminal": "正在执行相关操作",
+    "execute_code": "正在运行程序",
+    "image_generate": "正在生成图片",
+    "video_generate": "正在生成视频",
+    "text_to_speech": "正在生成语音",
+    "vision_analyze": "正在查看图片",
+    "session_search": "正在回顾之前的内容",
+    "skill_view": "正在查看相关技能",
+    "skills_list": "正在查找可用技能",
+    "skill_manage": "正在更新相关技能",
+    "delegate_task": "正在处理子任务",
+    "cronjob": "正在安排任务",
+    "clarify": "正在确认你的需求",
+    "memory": "正在整理相关记忆",
+    "todo": "正在处理任务列表",
+}
+
+_NO_TOOL_PROGRESS = "还在为你处理，请稍等"
+_UNKNOWN_TOOL_PROGRESS = "正在处理，请稍等"
+_COMPLETED_PROGRESS = "这一步已经完成，正在继续处理。"
+
+
+class HermesProgressNarrator:
+    """将真实 Hermes 工具事件转换为 voice-safe 进度提示。"""
+
+    def __init__(self, user_text: str):
+        # 保留现有调用签名，但用户问题不再参与 progress 语义选择。
+        del user_text
+        self._latest_status: tuple[str, str] | None = None
+        self._received_tool_progress = False
+        self._active_calls: dict[str, str] = {}
+        self._announced: set[str] = set()
+        self._completed_since_announcement = False
+        self._organizing_announced = False
+
+    def observe(self, event: HermesToolProgress):
+        self._received_tool_progress = True
+        tool = str(event.tool or "").strip().lower()
+        message = HERMES_TOOL_VOICE_STATUS.get(tool)
+        status_key = f"tool:{tool}" if message else "tool:unknown"
+        call_key = event.tool_call_id or (
+            f"{event.tool}:{event.status}"
+        )
+        if event.status == "running":
+            self._latest_status = (
+                message or _UNKNOWN_TOOL_PROGRESS,
+                status_key,
+            )
+            self._active_calls[call_key] = status_key
+        elif event.status == "completed":
+            completed_key = self._active_calls.pop(call_key, None)
+            if completed_key is not None:
+                self._completed_since_announcement = True
+                if (
+                    self._latest_status
+                    and self._latest_status[1] == completed_key
+                ):
+                    self._latest_status = None
+        elif event.status == "failed":
+            # 失败只结束对应调用，绝不能进入成功汇总路径。
+            # Hermes 仍可继续执行其他工具并自行生成最终回答。
+            failed_key = self._active_calls.pop(call_key, None)
+            if (
+                failed_key is not None
+                and self._latest_status
+                and self._latest_status[1] == failed_key
+            ):
+                self._latest_status = None
+
+    def next_message(self) -> tuple[str, str] | None:
+        """返回安全提示和用于语义去重的键。"""
+
+        if (
+            self._completed_since_announcement
+            and self._announced
+            and not self._organizing_announced
+        ):
+            self._completed_since_announcement = False
+            self._organizing_announced = True
+            return _COMPLETED_PROGRESS, "organizing"
+
+        if self._latest_status:
+            message, key = self._latest_status
+            if key not in self._announced:
+                self._announced.add(key)
+                return message, key
+
+        if not self._announced:
+            key = (
+                "tool:unknown"
+                if self._received_tool_progress
+                else "working"
+            )
+            self._announced.add(key)
+            return (
+                _UNKNOWN_TOOL_PROGRESS
+                if self._received_tool_progress
+                else _NO_TOOL_PROGRESS,
+                key,
+            )
+        return None

--- a/core/openai_stream.py
+++ b/core/openai_stream.py
@@ -1,0 +1,261 @@
+"""协议中立的 OpenAI-compatible 文本流辅助组件。"""
+
+from __future__ import annotations
+
+import codecs
+from collections.abc import Awaitable, Callable
+from dataclasses import dataclass
+import inspect
+import json
+import re
+import time
+from typing import Any
+
+import aiohttp
+
+from core.utils.logger import logger
+
+
+class OpenAIStreamError(RuntimeError):
+    """流式请求失败或服务端返回了不支持的响应。"""
+
+
+@dataclass(frozen=True)
+class SSEEvent:
+    """一个已经解码的 Server-Sent Event。"""
+
+    event: str
+    data: str
+
+
+class SSEDecoder:
+    """增量解码 SSE，不假设网络分块恰好落在事件边界。"""
+
+    def __init__(self):
+        self._buffer = ""
+
+    def feed(self, text: str, *, final: bool = False) -> list[SSEEvent]:
+        self._buffer += text.replace("\r\n", "\n").replace("\r", "\n")
+        blocks = self._buffer.split("\n\n")
+        if final:
+            self._buffer = ""
+        else:
+            self._buffer = blocks.pop()
+
+        events: list[SSEEvent] = []
+        for block in blocks:
+            event = "message"
+            data_lines: list[str] = []
+            for line in block.splitlines():
+                if not line or line.startswith(":"):
+                    continue
+                field, separator, value = line.partition(":")
+                if separator and value.startswith(" "):
+                    value = value[1:]
+                if field == "event":
+                    event = value or "message"
+                elif field == "data":
+                    data_lines.append(value)
+            if data_lines:
+                events.append(
+                    SSEEvent(event=event, data="\n".join(data_lines))
+                )
+        return events
+
+
+class SentenceChunker:
+    """将流式文本整理为有序且适合 TTS 的句段。"""
+
+    _BOUNDARY_RE = re.compile(r"[。！？!?；;\n]")
+
+    def __init__(self, min_chars: int = 24, max_chars: int = 160):
+        self.min_chars = max(1, int(min_chars))
+        self.max_chars = max(self.min_chars, int(max_chars))
+        self._buffer = ""
+
+    def feed(self, delta: str, *, final: bool = False) -> list[str]:
+        self._buffer += delta
+        chunks: list[str] = []
+
+        while True:
+            boundaries = list(self._BOUNDARY_RE.finditer(self._buffer))
+            if not boundaries:
+                break
+
+            cut = None
+            for match in boundaries:
+                if match.end() >= self.min_chars:
+                    cut = match.end()
+                    break
+            if cut is None:
+                if final:
+                    cut = boundaries[-1].end()
+                else:
+                    break
+
+            chunk = self._buffer[:cut].strip()
+            self._buffer = self._buffer[cut:].lstrip()
+            chunks.extend(self._split_oversized(chunk))
+
+        if final and self._buffer.strip():
+            chunks.extend(self._split_oversized(self._buffer.strip()))
+            self._buffer = ""
+        return [chunk for chunk in chunks if chunk]
+
+    def _split_oversized(self, text: str) -> list[str]:
+        if len(text) <= self.max_chars:
+            return [text]
+        return [
+            text[index:index + self.max_chars].strip()
+            for index in range(0, len(text), self.max_chars)
+            if text[index:index + self.max_chars].strip()
+        ]
+
+
+def extract_openai_delta(data: str) -> tuple[str, str | None]:
+    """从一条 OpenAI SSE 数据中提取文本增量和结束原因。"""
+
+    body = json.loads(data)
+    choices = body.get("choices") if isinstance(body, dict) else None
+    if not choices or not isinstance(choices[0], dict):
+        return "", None
+    choice = choices[0]
+    delta = choice.get("delta")
+    content = delta.get("content") if isinstance(delta, dict) else ""
+    if isinstance(content, list):
+        content = "".join(
+            item.get("text", "")
+            for item in content
+            if isinstance(item, dict) and item.get("type") == "text"
+        )
+    return (
+        content if isinstance(content, str) else "",
+        choice.get("finish_reason"),
+    )
+
+
+async def _invoke_callback(callback, value):
+    result = callback(value)
+    if inspect.isawaitable(result):
+        await result
+
+
+async def stream_openai_chat_completion(
+    manager,
+    text: str,
+    *,
+    on_delta: Callable[[str], Awaitable[None] | None],
+    on_event: Callable[[SSEEvent], Awaitable[None] | None] | None = None,
+    log_name: str = "OpenAI Stream",
+) -> str:
+    """流式接收标准 OpenAI 文本，不解释具名事件的业务语义。"""
+
+    if not manager._initialized:
+        manager.initialize_from_config()
+    if not manager._enabled:
+        raise OpenAIStreamError(f"{log_name} backend is disabled")
+
+    session_key = manager._session_key
+    scope_key = (
+        manager._conversation_scope_key(session_key)
+        if hasattr(manager, "_conversation_scope_key")
+        else session_key
+    )
+    history = manager._sessions.setdefault(scope_key, [])
+    messages = manager._build_messages(history, text)
+    payload: dict[str, Any] = {
+        "model": manager._model,
+        "messages": messages,
+        "stream": True,
+        **manager._extra_body,
+    }
+    if manager._temperature is not None:
+        payload["temperature"] = manager._temperature
+    if manager._max_tokens is not None:
+        payload["max_tokens"] = manager._max_tokens
+
+    started_at = time.monotonic()
+    text_parts: list[str] = []
+    finish_reason: str | None = None
+    decoder = SSEDecoder()
+    utf8_decoder = codecs.getincrementaldecoder("utf-8")()
+
+    async def consume_event(event: SSEEvent):
+        nonlocal finish_reason
+        if event.event != "message":
+            if on_event:
+                await _invoke_callback(on_event, event)
+            return
+        if event.data == "[DONE]":
+            return
+        try:
+            delta, event_finish_reason = extract_openai_delta(event.data)
+        except Exception as exc:
+            logger.debug(
+                f"Ignoring malformed SSE data event: {exc}",
+                module=log_name,
+            )
+            return
+        if event_finish_reason:
+            finish_reason = str(event_finish_reason)
+        if delta:
+            text_parts.append(delta)
+            await _invoke_callback(on_delta, delta)
+
+    async with aiohttp.ClientSession(
+        timeout=aiohttp.ClientTimeout(total=manager._timeout)
+    ) as session:
+        async with session.post(
+            manager._chat_completions_url(),
+            json=payload,
+            headers=manager._headers(),
+        ) as response:
+            if response.status >= 400:
+                error_text = await response.text()
+                raise OpenAIStreamError(
+                    f"HTTP {response.status}: {error_text[:500]}"
+                )
+            content_type = response.headers.get(
+                "Content-Type",
+                "",
+            ).lower()
+            if "text/event-stream" not in content_type:
+                raise OpenAIStreamError(
+                    f"Streaming unsupported: Content-Type={content_type!r}"
+                )
+            manager._capture_response_headers(
+                response.headers,
+                session_key=scope_key,
+            )
+
+            async for raw_chunk in response.content.iter_any():
+                decoded = utf8_decoder.decode(raw_chunk)
+                for event in decoder.feed(decoded):
+                    await consume_event(event)
+
+            tail = utf8_decoder.decode(b"", final=True)
+            for event in decoder.feed(tail, final=True):
+                await consume_event(event)
+
+    if finish_reason == "error":
+        raise OpenAIStreamError(
+            "Server ended the stream with finish_reason=error"
+        )
+
+    response_text = "".join(text_parts).strip()
+    if not response_text:
+        raise OpenAIStreamError(
+            "Streaming response contained no final text"
+        )
+
+    manager._append_history(history, text, response_text)
+    logger.ai_response(
+        response_text,
+        module=f"{log_name}({session_key})",
+    )
+    logger.info(
+        f"Streaming final response completed: chars={len(response_text)}, "
+        f"elapsed={time.monotonic() - started_at:.1f}s",
+        module=log_name,
+    )
+    return response_text

--- a/core/services/audio/kws/keywords.py
+++ b/core/services/audio/kws/keywords.py
@@ -34,6 +34,11 @@ def should_generate_keywords():
         "true",
         "yes",
     )
+    hermes_enabled = os.environ.get("HERMES_ENABLE", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
     qwenpaw_enabled = os.environ.get("QWENPAW_ENABLE", "").lower() in (
         "1",
         "true",
@@ -44,9 +49,10 @@ def should_generate_keywords():
         not xiaozhi_enabled
         and not openclaw_enabled
         and not openai_enabled
+        and not hermes_enabled
         and not qwenpaw_enabled
     ):
-        return False, "XIAOZHI_ENABLE, OPENCLAW_ENABLE/OPENCLAW_ENABLED, OPENAI_ENABLE and QWENPAW_ENABLE are all disabled"
+        return False, "XIAOZHI_ENABLE, OPENCLAW_ENABLE/OPENCLAW_ENABLED, OPENAI_ENABLE, HERMES_ENABLE and QWENPAW_ENABLE are all disabled"
 
     return True, ""
 

--- a/core/speech_queue.py
+++ b/core/speech_queue.py
@@ -1,0 +1,150 @@
+"""流式对话后端使用的单工作线程语音队列。"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import deque
+from dataclasses import dataclass
+from typing import Literal
+
+
+SpeechKind = Literal["progress", "final"]
+
+
+@dataclass(frozen=True)
+class SpeechItem:
+    """一条等待顺序 TTS 播放的内容。"""
+
+    kind: SpeechKind
+    text: str
+    key: str = ""
+
+
+class SequentialSpeechQueue:
+    """串行播放 TTS，并原子丢弃已被最终回答淘汰的进度。
+
+    已经开始的内容不会被打断。若最终文本先到，删除待播进度；若进度已
+    开始，则让它播完，再播放最终回答。
+    """
+
+    def __init__(self):
+        self._condition = asyncio.Condition()
+        self._items: deque[SpeechItem] = deque()
+        self._closed = False
+        self._aborted = False
+        self._final_started = False
+        self._playing: SpeechItem | None = None
+
+    @property
+    def final_started(self) -> bool:
+        return self._final_started
+
+    @property
+    def playing(self) -> SpeechItem | None:
+        return self._playing
+
+    @property
+    def aborted(self) -> bool:
+        return self._aborted
+
+    async def mark_final_started(self) -> int:
+        """阻止后续进度，并原子删除待播进度。"""
+
+        async with self._condition:
+            if self._aborted or self._final_started:
+                return 0
+            self._final_started = True
+            kept = deque(
+                item for item in self._items
+                if item.kind != "progress"
+            )
+            removed = len(self._items) - len(kept)
+            self._items = kept
+            self._condition.notify_all()
+            return removed
+
+    async def put_progress(self, text: str, *, key: str) -> bool:
+        """最终文本尚未到达时，加入一条不重复的进度。"""
+
+        async with self._condition:
+            if self._closed or self._aborted or self._final_started:
+                return False
+            if (
+                self._playing
+                and self._playing.kind == "progress"
+                and self._playing.key == key
+            ):
+                return False
+            if any(
+                item.kind == "progress" and item.key == key
+                for item in self._items
+            ):
+                return False
+            self._items = deque(
+                item for item in self._items
+                if item.kind != "progress"
+            )
+            self._items.append(SpeechItem("progress", text, key))
+            self._condition.notify()
+            return True
+
+    async def put_final(self, text: str) -> bool:
+        """按到达顺序加入最终文本。"""
+
+        normalized = text.strip()
+        if not normalized:
+            return False
+        await self.mark_final_started()
+        async with self._condition:
+            if self._closed or self._aborted:
+                return False
+            self._items.append(SpeechItem("final", normalized))
+            self._condition.notify()
+            return True
+
+    async def get(self) -> SpeechItem | None:
+        """返回下一条内容；关闭且队列耗尽后返回 ``None``。"""
+
+        async with self._condition:
+            while not self._items and not self._closed and not self._aborted:
+                await self._condition.wait()
+            if self._aborted or not self._items:
+                return None
+            item = self._items.popleft()
+            self._playing = item
+            return item
+
+    async def finish(self, item: SpeechItem):
+        """将一条内容标记为播放结束。"""
+
+        async with self._condition:
+            if self._playing is item:
+                self._playing = None
+            self._condition.notify_all()
+
+    async def drain(self):
+        """正常结束：停止接收新内容，并让已有队列自然耗尽。"""
+
+        async with self._condition:
+            if self._aborted:
+                return
+            self._closed = True
+            self._condition.notify_all()
+
+    async def close(self):
+        """兼容旧调用；语义等同于 :meth:`drain`。"""
+
+        await self.drain()
+
+    async def abort(self) -> int:
+        """主动中断：原子停止接收并丢弃全部尚未播放的内容。"""
+
+        async with self._condition:
+            if self._aborted:
+                return 0
+            self._aborted = True
+            self._closed = True
+            removed = len(self._items)
+            self._items.clear()
+            self._condition.notify_all()
+            return removed

--- a/core/streaming_conversation.py
+++ b/core/streaming_conversation.py
@@ -1,0 +1,319 @@
+"""外部对话后端共用的流式文本交付逻辑。"""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from core.external_conversation import ExternalConversationController
+from core.openai_stream import SentenceChunker
+from core.ref import get_speaker
+from core.speech_queue import SequentialSpeechQueue
+from core.utils.logger import logger
+
+
+class _SpeechWorkerFailed(RuntimeError):
+    """Playback worker failed independently of the network stream."""
+
+
+class StreamingConversationController(ExternalConversationController):
+    """通过单个竞态安全的 TTS 工作线程交付流式回答。"""
+
+    STREAMING_DEFAULT = False
+
+    def stop(self):
+        """停止会话，并取消当前由本 controller 持有的流式 turn。"""
+
+        turn_task = getattr(self, "_streaming_turn_task", None)
+        super().stop()
+        if turn_task and not turn_task.done():
+            turn_task.get_loop().call_soon_threadsafe(turn_task.cancel)
+
+    def _stream_config(self) -> dict[str, Any]:
+        value = self._cfg("streaming", self.STREAMING_DEFAULT)
+        if isinstance(value, dict):
+            return value
+        return {"enabled": bool(value)}
+
+    def _streaming_enabled(self) -> bool:
+        return bool(
+            self._stream_config().get(
+                "enabled",
+                self.STREAMING_DEFAULT,
+            )
+        )
+
+    def _progress_config(self) -> dict[str, Any]:
+        return {}
+
+    def _create_progress_narrator(self, _text: str):
+        return None
+
+    async def _request_stream(
+        self,
+        prompt: str,
+        *,
+        on_delta,
+        on_progress,
+    ) -> str | None:
+        """请求后端流；具体传输由子类定义。"""
+
+        raise NotImplementedError
+
+    async def _request_backend_turn(
+        self,
+        text: str,
+        *,
+        play_send_sound: bool,
+    ) -> tuple[str | None, bool]:
+        if not self._streaming_enabled():
+            return await super()._request_backend_turn(
+                text,
+                play_send_sound=play_send_sound,
+            )
+        return await self._request_streaming_turn(
+            text,
+            play_send_sound=play_send_sound,
+        )
+
+    async def _request_streaming_turn(
+        self,
+        text: str,
+        *,
+        play_send_sound: bool,
+    ) -> tuple[str | None, bool]:
+        """将完整句段流式送入一个顺序 TTS 队列。"""
+
+        prompt = text
+        if self.backend._rule_prompt:
+            prompt = text + "\n" + self.backend._rule_prompt
+
+        stream_config = self._stream_config()
+        chunker = SentenceChunker(
+            min_chars=int(
+                stream_config.get("sentence_min_chars", 24)
+            ),
+            max_chars=int(
+                stream_config.get("sentence_max_chars", 160)
+            ),
+        )
+        speech_queue = SequentialSpeechQueue()
+        playback_ready = asyncio.Event()
+        progress_stop = asyncio.Event()
+        received_parts: list[str] = []
+        delivered_final_chunks: list[str] = []
+        narrator = self._create_progress_narrator(text)
+
+        async def playback_worker():
+            await playback_ready.wait()
+            while True:
+                item = await speech_queue.get()
+                if item is None:
+                    return
+                try:
+                    await self._play_tts(item.text)
+                finally:
+                    await speech_queue.finish(item)
+
+        async def on_delta(delta: str):
+            if not delta:
+                return
+            received_parts.append(delta)
+            removed = await speech_queue.mark_final_started()
+            if removed:
+                logger.debug(
+                    f"Skipped {removed} stale queued progress item(s)",
+                    module=self.LOG_MODULE,
+                )
+            for sentence in chunker.feed(delta):
+                delivered_final_chunks.append(sentence)
+                await speech_queue.put_final(sentence)
+
+        async def on_progress(event):
+            if narrator is not None:
+                narrator.observe(event)
+
+        async def progress_announcer():
+            progress = self._progress_config()
+            if narrator is None or not bool(
+                progress.get("enabled", True)
+            ):
+                return
+            initial_delay = max(
+                1.0,
+                float(progress.get("initial_delay", 8)),
+            )
+            min_interval = max(
+                3.0,
+                float(progress.get("min_interval", 20)),
+            )
+            max_messages = max(
+                0,
+                int(progress.get("max_messages", 2)),
+            )
+
+            await playback_ready.wait()
+            try:
+                await asyncio.wait_for(
+                    progress_stop.wait(),
+                    timeout=initial_delay,
+                )
+                return
+            except asyncio.TimeoutError:
+                pass
+
+            for _ in range(max_messages):
+                if speech_queue.final_started or progress_stop.is_set():
+                    return
+                announcement = narrator.next_message()
+                if announcement:
+                    message, key = announcement
+                    await speech_queue.put_progress(message, key=key)
+                try:
+                    await asyncio.wait_for(
+                        progress_stop.wait(),
+                        timeout=min_interval,
+                    )
+                    return
+                except asyncio.TimeoutError:
+                    continue
+
+        worker_task: asyncio.Task | None = None
+        progress_task: asyncio.Task | None = None
+        stream_task: asyncio.Task | None = None
+        turn_task = asyncio.current_task()
+        self._streaming_turn_task = turn_task
+
+        async def abort_turn():
+            """丢弃旧语音并回收本 turn 创建的全部任务。"""
+
+            progress_stop.set()
+            removed = await speech_queue.abort()
+            if removed:
+                logger.debug(
+                    f"Discarded {removed} queued speech item(s) on abort",
+                    module=self.LOG_MODULE,
+                )
+
+            child_tasks = tuple(
+                task
+                for task in (stream_task, progress_task, worker_task)
+                if task is not None
+            )
+            for task in child_tasks:
+                if not task.done():
+                    task.cancel()
+
+            speaker = get_speaker()
+            if speaker:
+                try:
+                    await speaker.stop_device_audio()
+                except Exception as exc:
+                    logger.debug(
+                        f"Failed to stop aborted turn audio: {exc}",
+                        module=self.LOG_MODULE,
+                    )
+
+            if child_tasks:
+                await asyncio.gather(
+                    *child_tasks,
+                    return_exceptions=True,
+                )
+            await self._start_recording()
+
+        async def cleanup_despite_cancellation():
+            """重复 cancel 时仍等待 cleanup 真正结束。"""
+
+            cleanup_task = asyncio.create_task(abort_turn())
+            while not cleanup_task.done():
+                try:
+                    await asyncio.shield(cleanup_task)
+                except asyncio.CancelledError:
+                    continue
+            await cleanup_task
+
+        async def wait_for_stream():
+            """等待流，同时让 playback worker 的异常能及时终止 turn。"""
+
+            done, _pending = await asyncio.wait(
+                {stream_task, worker_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if worker_task in done:
+                try:
+                    await worker_task
+                except asyncio.CancelledError:
+                    raise
+                except Exception as exc:
+                    raise _SpeechWorkerFailed(
+                        "Speech worker failed during streaming"
+                    ) from exc
+                if not stream_task.done():
+                    raise _SpeechWorkerFailed(
+                        "Speech worker exited before streaming completed"
+                    )
+            return await stream_task
+
+        try:
+            await self._stop_recording()
+            # 从第一个子任务创建开始，全部生命周期都受本 try/except 保护。
+            worker_task = asyncio.create_task(playback_worker())
+            progress_task = asyncio.create_task(progress_announcer())
+            logger.user_speech(
+                prompt,
+                module=f"{self.BACKEND_NAME}({self.backend._session_key})",
+            )
+            stream_task = asyncio.create_task(
+                self._request_stream(
+                    prompt,
+                    on_delta=on_delta,
+                    on_progress=on_progress,
+                )
+            )
+
+            if play_send_sound:
+                await self._play_send_sound()
+            playback_ready.set()
+
+            response: str | None = None
+            try:
+                response = await wait_for_stream()
+            except asyncio.CancelledError:
+                raise
+            except _SpeechWorkerFailed:
+                raise
+            except Exception as exc:
+                logger.error(
+                    "Streaming interrupted; the Agent turn will not be "
+                    f"submitted again: {type(exc).__name__}: {exc}",
+                    module=self.LOG_MODULE,
+                )
+                # 交付已经收到但尚未成句的正文；stream helper 只有完整成功
+                # 才写 history，因此这里不会把不完整回答记成成功轮次。
+                for sentence in chunker.feed("", final=True):
+                    delivered_final_chunks.append(sentence)
+                    await speech_queue.put_final(sentence)
+                interruption = "回答传输中断了，请再问一次"
+                delivered_final_chunks.append(interruption)
+                await speech_queue.put_final(interruption)
+                response = "".join(received_parts).strip() or None
+
+            # 成功流的末尾可能还留有一个不足最小句长的正文片段。
+            for sentence in chunker.feed("", final=True):
+                delivered_final_chunks.append(sentence)
+                await speech_queue.put_final(sentence)
+
+            progress_stop.set()
+            await progress_task
+            await speech_queue.drain()
+            await worker_task
+            return response, bool(delivered_final_chunks)
+        except asyncio.CancelledError:
+            await cleanup_despite_cancellation()
+            raise
+        except BaseException:
+            await cleanup_despite_cancellation()
+            raise
+        finally:
+            if getattr(self, "_streaming_turn_task", None) is turn_task:
+                self._streaming_turn_task = None

--- a/core/wakeup_session.py
+++ b/core/wakeup_session.py
@@ -20,6 +20,8 @@ class WakeupSessionManager:
         self._openclaw_task: asyncio.Task | None = None
         self._openai_controller = None
         self._openai_task: asyncio.Task | None = None
+        self._hermes_controller = None
+        self._hermes_task: asyncio.Task | None = None
         self._qwenpaw_controller = None
         self._qwenpaw_task: asyncio.Task | None = None
         self._xiaozhi_future: asyncio.Future | None = None
@@ -72,6 +74,10 @@ class WakeupSessionManager:
             self._openai_controller.stop()
         if self._openai_task and not self._openai_task.done():
             loop.call_soon_threadsafe(self._openai_task.cancel)
+        if self._hermes_controller and self._hermes_controller.is_active():
+            self._hermes_controller.stop()
+        if self._hermes_task and not self._hermes_task.done():
+            loop.call_soon_threadsafe(self._hermes_task.cancel)
         if self._qwenpaw_controller and self._qwenpaw_controller.is_active():
             self._qwenpaw_controller.stop()
         if self._qwenpaw_task and not self._qwenpaw_task.done():
@@ -117,6 +123,7 @@ class WakeupSessionManager:
         for controller in (
             self._openclaw_controller,
             self._openai_controller,
+            self._hermes_controller,
             self._qwenpaw_controller,
         ):
             if controller and controller.is_active():
@@ -145,6 +152,11 @@ class WakeupSessionManager:
             "openai", {}
         ).get("session_key", "agent:default:open-xiaoai-bridge")
         OpenAIManager._session_key = default_openai_session_key
+        from core.hermes import HermesManager
+        default_hermes_session_key = self.config.get_app_config(
+            "hermes", {}
+        ).get("session_key", "agent:default:open-xiaoai-bridge")
+        HermesManager._session_key = default_hermes_session_key
         from core.qwenpaw import QwenPawManager
         default_qwenpaw_session_key = self.config.get_app_config(
             "qwenpaw", {}
@@ -169,6 +181,8 @@ class WakeupSessionManager:
             await self._start_openclaw_conversation()
         elif should_wakeup == "openai":
             await self._start_openai_conversation()
+        elif should_wakeup == "hermes":
+            await self._start_hermes_conversation()
         elif should_wakeup == "qwenpaw":
             await self._start_qwenpaw_conversation()
         elif should_wakeup == "xiaozhi":
@@ -226,6 +240,36 @@ class WakeupSessionManager:
             if kws:
                 kws.resume()
 
+    async def _start_hermes_conversation(self):
+        """启动 Hermes Agent 连续对话会话。"""
+        from core.hermes_conversation import HermesConversationController
+
+        kws = get_kws()
+        if kws:
+            kws.pause()
+        controller = HermesConversationController()
+        task = asyncio.create_task(controller.start())
+        self._hermes_controller = controller
+        self._hermes_task = task
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception as exc:
+            logger.error(
+                f"[Wakeup] Hermes conversation failed: "
+                f"{type(exc).__name__}: {exc}",
+                module="Wakeup",
+            )
+        finally:
+            # 旧 wakeup 的 finally 不得清掉刚启动的新 Hermes 会话。
+            if self._hermes_controller is controller:
+                self._hermes_controller = None
+            if self._hermes_task is task:
+                self._hermes_task = None
+            if kws:
+                kws.resume()
+
     async def _start_qwenpaw_conversation(self):
         """Start a QwenPaw continuous conversation session."""
         from core.qwenpaw_conversation import QwenPawConversationController
@@ -275,8 +319,21 @@ class WakeupSessionManager:
             self._openclaw_controller.stop()
         if self._openai_controller and self._openai_controller.is_active():
             self._openai_controller.stop()
+        if self._hermes_controller and self._hermes_controller.is_active():
+            self._hermes_controller.stop()
         if self._qwenpaw_controller and self._qwenpaw_controller.is_active():
             self._qwenpaw_controller.stop()
+
+        # 新会话开始前必须等旧 Hermes worker/stream/progress 全部回收；
+        # 其他后端保持既有 reset 语义，不在本次修复中扩大行为变化。
+        hermes_task = self._hermes_task
+        if (
+            hermes_task
+            and not hermes_task.done()
+            and hermes_task is not asyncio.current_task()
+        ):
+            hermes_task.cancel()
+            await asyncio.gather(hermes_task, return_exceptions=True)
 
         # Stop all audio playback on the device
         await self._stop_device_playback()

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - API_SERVER_ENABLE=1 # 启用 HTTP API 服务（可选）
       - API_SERVER_HOST=0.0.0.0 # HTTP API 服务监听地址（默认监听 127.0.0.1）
       - OPENCLAW_ENABLE=1       # 启用 OpenClaw（兼容旧值 OPENCLAW_ENABLED）
+      # - HERMES_ENABLE=1        # 启用 Hermes Agent 后端（可选）
       # - QWENPAW_ENABLE=1       # 启用 QwenPaw（可选）
       # - XIAOZHI_ENABLE=1       # 启用小智 AI（可选）
     volumes:

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ enable_api_server = False  # 是否开启 API Server
 
 def setup_config():
     """解析命令行参数和环境变量"""
-    global connect_xiaozhi, enable_api_server, enable_xiaozhi, enable_openclaw, enable_openai, enable_qwenpaw
+    global connect_xiaozhi, enable_api_server, enable_xiaozhi, enable_openclaw, enable_openai, enable_hermes, enable_qwenpaw
 
     parser = argparse.ArgumentParser(description="小爱音箱接入 Open XiaoAI")
     parser.parse_args()
@@ -51,6 +51,11 @@ def setup_config():
     openclaw_env = os.environ.get("OPENCLAW_ENABLE") or os.environ.get("OPENCLAW_ENABLED") or ""
     enable_openclaw = openclaw_env.lower() in ("1", "true", "yes")
     enable_openai = os.environ.get("OPENAI_ENABLE", "").lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+    enable_hermes = os.environ.get("HERMES_ENABLE", "").lower() in (
         "1",
         "true",
         "yes",
@@ -68,6 +73,7 @@ def setup_config():
                 f"API_SERVER_ENABLE={os.environ.get('API_SERVER_ENABLE') or 'not set (disabled)'}, "
                 f"OPENCLAW_ENABLE={os.environ.get('OPENCLAW_ENABLE') or os.environ.get('OPENCLAW_ENABLED') or 'not set (disabled)'}, "
                 f"OPENAI_ENABLE={os.environ.get('OPENAI_ENABLE') or 'not set (disabled)'}, "
+                f"HERMES_ENABLE={os.environ.get('HERMES_ENABLE') or 'not set (disabled)'}, "
                 f"QWENPAW_ENABLE={os.environ.get('QWENPAW_ENABLE') or 'not set (disabled)'}, "
                 f"AUDIO_INPUT_ENABLE={1 if audio_input_enabled else 0}")
     logger.info(f"[Main] Using config file: {config_path}")
@@ -88,6 +94,10 @@ def setup_config():
         module="Main",
     )
     logger.info(
+        f"Hermes Agent: {'启用' if enable_hermes else '禁用'}",
+        module="Main",
+    )
+    logger.info(
         f"QwenPaw: {'启用' if enable_qwenpaw else '禁用'}",
         module="Main",
     )
@@ -103,7 +113,7 @@ def run_services(xiaozhi_mode: bool = False):
     Args:
         xiaozhi_mode: 是否启动小智 AI 完整服务（包括 VAD/KWS/GUI）
     """
-    global main_app_instance, enable_api_server, enable_openclaw, enable_openai, enable_qwenpaw
+    global main_app_instance, enable_api_server, enable_openclaw, enable_openai, enable_hermes, enable_qwenpaw
 
     # 统一使用 MainApp 管理所有服务
     main_app_instance = MainApp.instance(
@@ -111,6 +121,7 @@ def run_services(xiaozhi_mode: bool = False):
         enable_openclaw=enable_openclaw,
         enable_openai=enable_openai,
         enable_qwenpaw=enable_qwenpaw,
+        enable_hermes=enable_hermes,
     )
     main_app_instance.run(enable_api_server=enable_api_server)
 

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -24,6 +24,7 @@ XIAOZHI_ENABLED=$(printf '%s' "${XIAOZHI_ENABLE:-}" | tr '[:upper:]' '[:lower:]'
 # 兼容 OPENCLAW_ENABLE (新) 和 OPENCLAW_ENABLED (旧)
 OPENCLAW_ENABLE_VALUE=$(printf '%s' "${OPENCLAW_ENABLE:-${OPENCLAW_ENABLED:-}}" | tr '[:upper:]' '[:lower:]')
 OPENAI_ENABLE_VALUE=$(printf '%s' "${OPENAI_ENABLE:-}" | tr '[:upper:]' '[:lower:]')
+HERMES_ENABLE_VALUE=$(printf '%s' "${HERMES_ENABLE:-}" | tr '[:upper:]' '[:lower:]')
 QWENPAW_ENABLE_VALUE=$(printf '%s' "${QWENPAW_ENABLE:-}" | tr '[:upper:]' '[:lower:]')
 
 # 1. 检查 uv
@@ -52,7 +53,7 @@ ONNX_LIB_DIR="$(uv run python -c "from pathlib import Path; import onnxruntime; 
     export DYLD_LIBRARY_PATH="${ONNX_LIB_DIR}${DYLD_LIBRARY_PATH:+:$DYLD_LIBRARY_PATH}"
 
 # 3. 检查 KWS 相关模型和关键词文件
-if [[ "$XIAOZHI_ENABLED" =~ ^(1|true|yes)$ ]] || [[ "$OPENCLAW_ENABLE_VALUE" =~ ^(1|true|yes)$ ]] || [[ "$OPENAI_ENABLE_VALUE" =~ ^(1|true|yes)$ ]] || [[ "$QWENPAW_ENABLE_VALUE" =~ ^(1|true|yes)$ ]]; then
+if [[ "$XIAOZHI_ENABLED" =~ ^(1|true|yes)$ ]] || [[ "$OPENCLAW_ENABLE_VALUE" =~ ^(1|true|yes)$ ]] || [[ "$OPENAI_ENABLE_VALUE" =~ ^(1|true|yes)$ ]] || [[ "$HERMES_ENABLE_VALUE" =~ ^(1|true|yes)$ ]] || [[ "$QWENPAW_ENABLE_VALUE" =~ ^(1|true|yes)$ ]]; then
     MODEL_DIR="core/models"
     REQUIRED_MODELS=("silero_vad.onnx" "encoder.onnx" "decoder.onnx" "joiner.onnx" "tokens.txt" "bpe.model")
     MISSING_MODELS=()
@@ -142,7 +143,7 @@ if [[ "$XIAOZHI_ENABLED" =~ ^(1|true|yes)$ ]] || [[ "$OPENCLAW_ENABLE_VALUE" =~ 
         exit 1
     fi
 else
-    echo -e "${YELLOW}⚠ 小智、OpenClaw、OpenAI 和 QwenPaw 均未启用，跳过模型检查和关键词预生成${NC}"
+    echo -e "${YELLOW}⚠ 小智、OpenClaw、OpenAI、Hermes 和 QwenPaw 均未启用，跳过模型检查和关键词预生成${NC}"
 fi
 
 # 4. 检查配置

--- a/skills/xiaoai-tts/SKILL.md
+++ b/skills/xiaoai-tts/SKILL.md
@@ -1,6 +1,12 @@
 ---
 name: xiaoai-tts
 description: Control Xiaoai speaker via OpenXiaoAI Voice API for high-quality TTS playback. Use when the user wants to play voice notifications, announcements, or TTS through the Xiaoai speaker using the OpenXiaoAI HTTP API. Supports Doubao (ByteDance) TTS with emotions, voice types, and speed control. Triggers on queries like "小爱播报", "语音播报", "让小爱说", "读出来", "播报"， "xiaoai-tts"，"tts", "TTS", "小爱音箱语音播报".
+version: 1.1.0
+required_environment_variables:
+  - name: OPENXIAOAI_BASE_URL
+    prompt: OpenXiaoAI Bridge base URL
+    help: Example http://192.168.x.x:9092
+    required_for: XiaoAI playback HTTP API
 ---
 
 # XiaoAI TTS
@@ -16,6 +22,22 @@ OPENXIAOAI_BASE_URL="http://192.168.x.x:9092"  # OpenXiaoAI 服务地址
 ```
 
 ## 使用方法
+
+Hermes Agent 会把下面的 `${HERMES_SKILL_DIR}` 替换为本 Skill 的绝对路径，
+因此无需把工具额外安装到 `PATH`。OpenClaw 等已将工具安装到 `PATH` 的宿主，
+继续使用原来的 `xiaoai-tts` 命令即可。
+
+Hermes Agent 调用格式：
+
+```bash
+"${HERMES_SKILL_DIR}/tools/xiaoai-tts" health
+"${HERMES_SKILL_DIR}/tools/xiaoai-tts" tts "你好，我是小爱语音助手" --blocking
+```
+
+主动播报必须使用 `--blocking`。命令退出码 `0` 且输出
+`RESULT success=true completed=true` 才表示播放已完成；非阻塞调用只会返回
+`RESULT success=true accepted=true`，只能表述为“已接受请求”，不能声称已经播报。
+退出码非 `0` 或 `RESULT success=false` 表示失败，不得向用户声称已经播报。
 
 ```bash
 # 语音播报（优先 Doubao TTS，失败自动回退小爱自带 TTS）
@@ -114,4 +136,3 @@ xiaoai-tts tts "你好，我是你的专属语音助手" -s S_xxxxxxxx
 
 - Base URL: `http://{host}:9092`
 - Content-Type: `application/json`
-```

--- a/skills/xiaoai-tts/scripts/play_text.py
+++ b/skills/xiaoai-tts/scripts/play_text.py
@@ -50,11 +50,19 @@ def main():
     try:
         result = play_text(args.text, blocking=blocking, timeout=args.timeout)
         if result.get("success"):
-            print(f"🎵 播放成功")
+            if blocking:
+                print("🎵 播放完成")
+                print("RESULT success=true completed=true")
+            else:
+                print("🎵 Bridge 已接受后台播放请求")
+                print("RESULT success=true accepted=true")
         else:
-            print(f"⚠️ 播放可能失败: {result}")
+            print(f"❌ 播放失败: {result}", file=sys.stderr)
+            print("RESULT success=false", file=sys.stderr)
+            sys.exit(1)
     except Exception as e:
         print(f"❌ 错误: {e}")
+        print("RESULT success=false", file=sys.stderr)
         sys.exit(1)
 
 

--- a/skills/xiaoai-tts/scripts/tts_doubao.py
+++ b/skills/xiaoai-tts/scripts/tts_doubao.py
@@ -101,11 +101,19 @@ def main():
         )
         
         if result.get("success"):
-            print(f"🎵 火山 TTS 播放成功")
+            if args.blocking:
+                print("🎵 火山 TTS 播放完成")
+                print("RESULT success=true completed=true")
+            else:
+                print("🎵 Bridge 已接受火山 TTS 后台播放请求")
+                print("RESULT success=true accepted=true")
         else:
-            print(f"⚠️ 播放可能失败: {result}")
+            print(f"❌ 播放失败: {result}", file=sys.stderr)
+            print("RESULT success=false", file=sys.stderr)
+            sys.exit(1)
     except Exception as e:
         print(f"❌ 错误: {e}")
+        print("RESULT success=false", file=sys.stderr)
         sys.exit(1)
 
 

--- a/tests/test_external_conversation_hook.py
+++ b/tests/test_external_conversation_hook.py
@@ -1,0 +1,87 @@
+import asyncio
+import importlib
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class ExternalConversationHookTest(unittest.TestCase):
+    def setUp(self):
+        sys.modules["open_xiaoai_server"] = types.SimpleNamespace(
+            decode_audio=lambda *_args, **_kwargs: b"",
+        )
+        if str(ROOT) not in sys.path:
+            sys.path.insert(0, str(ROOT))
+        sys.modules.pop("core.external_conversation", None)
+        module = importlib.import_module("core.external_conversation")
+        self.controller = module.ExternalConversationController.__new__(
+            module.ExternalConversationController
+        )
+        self.controller._play_send_sound = mock.AsyncMock()
+
+    def test_local_asr_default_path_preserves_tracking_order(self):
+        calls = []
+        backend = types.SimpleNamespace(
+            _rule_prompt="原有规则",
+            _send_and_track=mock.AsyncMock(
+                side_effect=lambda text: calls.append(
+                    ("send", text)
+                ) or "run-1"
+            ),
+            _wait_response=mock.AsyncMock(
+                side_effect=lambda run_id: calls.append(
+                    ("wait", run_id)
+                ) or "回答"
+            ),
+        )
+        self.controller.backend = backend
+        self.controller._play_send_sound = mock.AsyncMock(
+            side_effect=lambda: calls.append(("sound", None))
+        )
+
+        response = asyncio.run(
+            self.controller._request_backend_turn(
+                "问题",
+                play_send_sound=True,
+            )
+        )
+
+        self.assertEqual(("回答", False), response)
+        self.assertEqual(
+            [
+                ("send", "问题\n原有规则"),
+                ("sound", None),
+                ("wait", "run-1"),
+            ],
+            calls,
+        )
+
+    def test_xiaoai_asr_default_path_stays_non_streaming(self):
+        backend = types.SimpleNamespace(
+            _rule_prompt="",
+            send=mock.AsyncMock(return_value="整段回答"),
+        )
+        self.controller.backend = backend
+
+        response = asyncio.run(
+            self.controller._request_backend_turn(
+                "问题",
+                play_send_sound=False,
+            )
+        )
+
+        self.assertEqual(("整段回答", False), response)
+        backend.send.assert_awaited_once_with(
+            "问题",
+            wait_response=True,
+        )
+        self.controller._play_send_sound.assert_not_awaited()
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hermes_backend.py
+++ b/tests/test_hermes_backend.py
@@ -1,0 +1,509 @@
+import ast
+import asyncio
+import importlib
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class _Config:
+    def __init__(self, values):
+        self.values = values
+        self.listeners = []
+
+    def get_app_config(self, path, default=None):
+        value = self.values
+        for key in path.split("."):
+            if not isinstance(value, dict) or key not in value:
+                return default
+            value = value[key]
+        return value
+
+    def add_reload_listener(self, listener):
+        self.listeners.append(listener)
+
+
+class HermesBackendTest(unittest.TestCase):
+    def setUp(self):
+        sys.modules["open_xiaoai_server"] = types.SimpleNamespace()
+        if isinstance(sys.modules.get("aiohttp"), types.SimpleNamespace):
+            sys.modules.pop("aiohttp", None)
+        importlib.import_module("aiohttp")
+        if str(ROOT) not in sys.path:
+            sys.path.insert(0, str(ROOT))
+        for name in ("core.openai", "core.hermes"):
+            sys.modules.pop(name, None)
+        self.openai_module = importlib.import_module("core.openai")
+        self.openai = self.openai_module.OpenAIManager
+        self.hermes_module = importlib.import_module("core.hermes")
+        self.hermes = self.hermes_module.HermesManager
+
+    def tearDown(self):
+        self.openai._sessions.clear()
+        self.hermes._sessions.clear()
+        self.hermes._hermes_session_ids.clear()
+        self.hermes._profile = ""
+        self.hermes._profile_api_keys = {}
+        self.hermes._response_mode = self.hermes.DEFAULT_RESPONSE_MODE
+        self.hermes._capabilities_checked = False
+        self.hermes._capabilities = None
+        self.hermes._capabilities_diagnostic = None
+
+    def test_openai_and_hermes_runtime_state_are_isolated(self):
+        self.openai._session_key = "plain-openai"
+        self.openai._session_header = "X-Hermes-Session-Key"
+        self.openai._sessions["plain-openai"] = [
+            {"role": "user", "content": "OpenAI history"}
+        ]
+        self.hermes._session_key = "agent:hermes:speaker"
+        self.hermes._session_header = "X-Hermes-Session-Key"
+
+        self.assertEqual(
+            "plain-openai",
+            self.openai._headers()["X-Hermes-Session-Key"],
+        )
+        self.assertEqual(
+            "agent:hermes:speaker",
+            self.hermes._headers()["X-Hermes-Session-Key"],
+        )
+        self.assertEqual({}, self.hermes._sessions)
+
+    def test_hermes_native_session_id_is_reused_within_conversation(self):
+        self.hermes._session_key = "agent:hermes:speaker"
+        scope_key = self.hermes._conversation_scope_key()
+
+        self.hermes._capture_response_headers(
+            {"X-Hermes-Session-Id": "session-123"},
+            session_key=scope_key,
+        )
+
+        self.assertEqual(
+            "session-123",
+            self.hermes._headers()["X-Hermes-Session-Id"],
+        )
+
+    def test_explicit_reset_discards_text_and_native_session(self):
+        self.hermes._session_key = "agent:hermes:speaker"
+        scope_key = self.hermes._conversation_scope_key()
+        self.hermes._sessions[scope_key] = [
+            {"role": "assistant", "content": "昨天已经播放"}
+        ]
+        self.hermes._hermes_session_ids[scope_key] = (
+            "session-yesterday"
+        )
+
+        self.hermes.reset_session()
+
+        self.assertNotIn(
+            scope_key,
+            self.hermes._sessions,
+        )
+        self.assertNotIn(
+            scope_key,
+            self.hermes._hermes_session_ids,
+        )
+
+    def test_hermes_does_not_add_per_wake_session_rotation(self):
+        source = (ROOT / "core/hermes.py").read_text(encoding="utf-8")
+        controller_source = (
+            ROOT / "core/hermes_conversation.py"
+        ).read_text(encoding="utf-8")
+
+        self.assertNotIn("begin_conversation", source)
+        self.assertNotIn("begin_conversation", controller_source)
+        self.assertNotIn("bridge-voice-", source)
+
+    def test_complete_response_uses_stream_false_and_captures_session(self):
+        posts = []
+
+        class FakeResponse:
+            status = 200
+            headers = {"X-Hermes-Session-Id": "session-complete"}
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+            async def json(self, **_kwargs):
+                return {
+                    "choices": [
+                        {
+                            "message": {
+                                "content": "完整回答"
+                            }
+                        }
+                    ]
+                }
+
+        class FakeSession:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+            def post(self, *_args, **kwargs):
+                posts.append(kwargs)
+                return FakeResponse()
+
+        self.hermes._session_key = "agent:hermes:complete"
+        self.hermes._model = "hermes-agent"
+        self.hermes._extra_body = {}
+        self.hermes._temperature = None
+        self.hermes._max_tokens = None
+        self.hermes._timeout = 10
+
+        async def scenario():
+            with (
+                mock.patch.object(
+                    self.hermes_module.aiohttp,
+                    "ClientSession",
+                    FakeSession,
+                ),
+                mock.patch.object(
+                    self.hermes_module.aiohttp,
+                    "ClientTimeout",
+                    lambda **_kwargs: object(),
+                ),
+            ):
+                return await self.hermes._request_chat_completion(
+                    "问题"
+                )
+
+        self.assertEqual("完整回答", asyncio.run(scenario()))
+        self.assertEqual(1, len(posts))
+        self.assertIs(False, posts[0]["json"]["stream"])
+        self.assertEqual(
+            "session-complete",
+            self.hermes._hermes_session_ids[
+                self.hermes._conversation_scope_key()
+            ],
+        )
+        self.assertEqual(
+            [
+                {"role": "user", "content": "问题"},
+                {"role": "assistant", "content": "完整回答"},
+            ],
+            self.hermes._sessions[
+                self.hermes._conversation_scope_key()
+            ],
+        )
+
+    def test_profiles_use_official_url_prefix_and_isolate_sessions(self):
+        self.hermes._base_url = "http://hermes.test/v1"
+        self.hermes._api_key = "default-key"
+        self.hermes._profile_api_keys = {"coder": "coder-key"}
+        self.hermes._session_key = "speaker"
+
+        default_scope = self.hermes._conversation_scope_key()
+        self.hermes._sessions[default_scope] = [{"role": "user", "content": "a"}]
+        self.hermes.set_profile("coder")
+        coder_scope = self.hermes._conversation_scope_key()
+
+        self.assertEqual(
+            "http://hermes.test/p/coder/v1/chat/completions",
+            self.hermes._chat_completions_url(),
+        )
+        self.assertEqual(
+            "Bearer coder-key",
+            self.hermes._headers()["Authorization"],
+        )
+        self.assertNotEqual(default_scope, coder_scope)
+        self.assertEqual([], self.hermes._sessions.get(coder_scope, []))
+
+    def test_named_profile_requires_its_own_api_key(self):
+        with self.assertRaisesRegex(ValueError, "No API key configured"):
+            self.hermes.set_profile("coder")
+
+    def test_main_app_exposes_session_controls(self):
+        from core import app as app_module
+
+        MainApp = app_module.MainApp
+        manager = app_module.HermesManager
+
+        with (
+            mock.patch.object(manager, "set_session_key") as set_key,
+            mock.patch.object(manager, "reset_session") as reset,
+            mock.patch.object(
+                manager,
+                "get_session_state",
+                return_value={"session_key": "speaker"},
+            ),
+            mock.patch.object(manager, "set_profile") as set_profile,
+        ):
+            MainApp.set_hermes_session_key(object(), "speaker")
+            MainApp.reset_hermes_session(object(), "speaker")
+            state = MainApp.get_hermes_session_state(object())
+            MainApp.set_hermes_profile(object(), "coder")
+
+        set_key.assert_called_once_with("speaker")
+        reset.assert_called_once_with("speaker")
+        set_profile.assert_called_once_with("coder")
+        self.assertEqual({"session_key": "speaker"}, state)
+
+    def test_agent_autonomous_path_does_not_auto_play_final(self):
+        from core import app as app_module
+
+        MainApp = app_module.MainApp
+        manager = app_module.HermesManager
+        manager._response_mode = "complete"
+        manager._rule_prompt_for_skill = "Use xiaoai-tts when needed."
+        with (
+            mock.patch.object(
+                manager,
+                "send",
+                new=mock.AsyncMock(return_value="run-1"),
+            ) as send,
+            mock.patch.object(
+                manager,
+                "send_and_play_reply",
+                new=mock.AsyncMock(),
+            ) as send_and_play,
+        ):
+            result = asyncio.run(
+                MainApp.send_to_hermes(object(), "提醒我喝水")
+            )
+
+        self.assertEqual("run-1", result)
+        send.assert_awaited_once_with(
+            "提醒我喝水\nUse xiaoai-tts when needed.",
+            wait_response=False,
+        )
+        send_and_play.assert_not_awaited()
+
+    def test_hermes_reads_only_its_own_configuration(self):
+        config = _Config(
+            {
+                "openai": {
+                    "base_url": "http://openai.test/v1",
+                    "model": "plain-model",
+                },
+                "hermes": {
+                    "base_url": "http://hermes.test/v1",
+                    "model": "hermes-model",
+                    "session_key": "agent:hermes:test",
+                },
+            }
+        )
+        self.hermes._reload_listener_registered = False
+
+        with (
+            mock.patch.object(
+                self.hermes_module.ConfigManager,
+                "instance",
+                return_value=config,
+            ),
+            mock.patch.object(
+                self.hermes_module,
+                "get_env",
+                return_value="true",
+            ),
+        ):
+            self.hermes.reload_from_config()
+
+        self.assertTrue(self.hermes._enabled)
+        self.assertEqual("http://hermes.test/v1", self.hermes._base_url)
+        self.assertEqual("hermes-model", self.hermes._model)
+        self.assertEqual("agent:hermes:test", self.hermes._session_key)
+        self.assertEqual("X-Hermes-Session-Key", self.hermes._session_header)
+        self.assertEqual("streaming", self.hermes.get_response_mode())
+
+    def test_response_mode_is_normalized_and_invalid_value_warns(self):
+        config = _Config(
+            {"hermes": {"response_mode": "  COMPLETE  "}}
+        )
+        self.hermes._reload_listener_registered = False
+        with (
+            mock.patch.object(
+                self.hermes_module.ConfigManager,
+                "instance",
+                return_value=config,
+            ),
+            mock.patch.object(
+                self.hermes_module,
+                "get_env",
+                return_value="true",
+            ),
+        ):
+            self.hermes.reload_from_config()
+        self.assertEqual("complete", self.hermes.get_response_mode())
+
+        config.values["hermes"]["response_mode"] = "automatic"
+        with (
+            mock.patch.object(
+                self.hermes_module.ConfigManager,
+                "instance",
+                return_value=config,
+            ),
+            mock.patch.object(
+                self.hermes_module,
+                "get_env",
+                return_value="true",
+            ),
+            mock.patch.object(
+                self.hermes_module.logger,
+                "warning",
+            ) as warning,
+        ):
+            self.hermes.reload_from_config()
+        self.assertEqual("streaming", self.hermes.get_response_mode())
+        warning.assert_called_once()
+
+    def test_response_mode_does_not_change_session_scope_or_native_id(self):
+        self.hermes._session_key = "speaker"
+        self.hermes._profile = ""
+        scope_key = self.hermes._conversation_scope_key()
+        self.hermes._sessions[scope_key] = [
+            {"role": "assistant", "content": "已有上下文"}
+        ]
+        self.hermes._hermes_session_ids[scope_key] = "native-session"
+
+        self.hermes._response_mode = "streaming"
+        streaming_scope = self.hermes._conversation_scope_key()
+        self.hermes._response_mode = "complete"
+        complete_scope = self.hermes._conversation_scope_key()
+
+        self.assertEqual(scope_key, streaming_scope)
+        self.assertEqual(scope_key, complete_scope)
+        self.assertEqual(
+            "native-session",
+            self.hermes._headers()["X-Hermes-Session-Id"],
+        )
+        self.assertEqual(1, len(self.hermes._sessions[scope_key]))
+
+    def test_main_app_adds_hermes_after_existing_backend_arguments(self):
+        tree = ast.parse((ROOT / "core/app.py").read_text(encoding="utf-8"))
+        main_app = next(
+            node
+            for node in tree.body
+            if isinstance(node, ast.ClassDef) and node.name == "MainApp"
+        )
+        expected = [
+            "enable_xiaozhi",
+            "enable_openclaw",
+            "enable_openai",
+            "enable_qwenpaw",
+            "enable_hermes",
+        ]
+        for method_name in ("instance", "__init__"):
+            method = next(
+                node
+                for node in main_app.body
+                if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef))
+                and node.name == method_name
+            )
+            argument_names = [argument.arg for argument in method.args.args]
+            self.assertEqual(expected, argument_names[-len(expected):])
+
+    def test_generic_openai_source_remains_upstream_compatible(self):
+        source = (ROOT / "core/openai.py").read_text(encoding="utf-8")
+        self.assertNotIn("hermes.tool.progress", source)
+        self.assertNotIn("HERMES_ENABLE", source)
+        self.assertNotIn("HermesManager", source)
+
+    def test_only_hermes_interprets_hermes_progress_events(self):
+        progress = []
+
+        async def fake_stream(
+            _manager,
+            _text,
+            *,
+            on_delta,
+            on_event,
+            log_name,
+        ):
+            del on_delta, log_name
+            event = types.SimpleNamespace(
+                event="hermes.tool.progress",
+                data=(
+                    '{"tool":"weather","status":"running",'
+                    '"toolCallId":"call-1"}'
+                ),
+            )
+            await on_event(event)
+            return "完成"
+
+        async def scenario():
+            with mock.patch.object(
+                self.hermes_module,
+                "stream_openai_chat_completion",
+                side_effect=fake_stream,
+            ):
+                return await self.hermes.request_streaming_chat_completion(
+                    "天气怎么样",
+                    on_delta=lambda _value: None,
+                    on_tool_progress=lambda event: progress.append(event),
+                )
+
+        self.assertEqual("完成", asyncio.run(scenario()))
+        self.assertEqual(["weather"], [event.tool for event in progress])
+
+    def test_default_routes_send_hermes_commands_directly_to_hermes(self):
+        spec = importlib.util.spec_from_file_location(
+            "hermes_route_config_test",
+            ROOT / "config.py",
+        )
+        config_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(config_module)
+        speaker = types.SimpleNamespace(
+            play=mock.AsyncMock(),
+            abort_xiaoai=mock.AsyncMock(),
+        )
+        app = types.SimpleNamespace()
+
+        kws_result = asyncio.run(
+            config_module.before_wakeup(
+                speaker,
+                "你好赫尔墨斯",
+                "kws",
+                app,
+            )
+        )
+        xiaoai_result = asyncio.run(
+            config_module.before_wakeup(
+                speaker,
+                "召唤赫尔墨斯",
+                "xiaoai",
+                app,
+            )
+        )
+
+        self.assertEqual("hermes", kws_result)
+        self.assertEqual("hermes", xiaoai_result)
+        speaker.abort_xiaoai.assert_awaited_once()
+
+    def test_generic_openai_defaults_do_not_gain_streaming_options(self):
+        spec = importlib.util.spec_from_file_location(
+            "hermes_config_boundary_test",
+            ROOT / "config.py",
+        )
+        config_module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(config_module)
+
+        openai_config = config_module.APP_CONFIG["openai"]
+        hermes_config = config_module.APP_CONFIG["hermes"]
+
+        self.assertEqual(
+            "X-Hermes-Session-Key",
+            openai_config["session_header"],
+        )
+        self.assertNotIn("streaming", openai_config)
+        self.assertNotIn("progress", openai_config)
+        self.assertEqual("streaming", hermes_config["response_mode"])
+        self.assertNotIn("enabled", hermes_config["streaming"])
+        self.assertTrue(hermes_config["progress"]["enabled"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hermes_capabilities.py
+++ b/tests/test_hermes_capabilities.py
@@ -1,0 +1,228 @@
+import asyncio
+import importlib
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class _Response:
+    def __init__(self, status, body=None, enter_error=None):
+        self.status = status
+        self.body = body
+        self.headers = {}
+        self.enter_error = enter_error
+
+    async def __aenter__(self):
+        if self.enter_error:
+            raise self.enter_error
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def json(self, **_kwargs):
+        return self.body
+
+
+class _Session:
+    def __init__(self, get_response, post_response=None, calls=None, **_kwargs):
+        self.get_response = get_response
+        self.post_response = post_response
+        self.calls = calls if calls is not None else []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    def get(self, url, **kwargs):
+        self.calls.append(("GET", url, kwargs))
+        return self.get_response
+
+    def post(self, url, **kwargs):
+        self.calls.append(("POST", url, kwargs))
+        return self.post_response
+
+
+class HermesCapabilitiesTest(unittest.TestCase):
+    def setUp(self):
+        sys.modules["open_xiaoai_server"] = types.SimpleNamespace()
+        if str(ROOT) not in sys.path:
+            sys.path.insert(0, str(ROOT))
+        sys.modules.pop("core.hermes", None)
+        self.module = importlib.import_module("core.hermes")
+        self.hermes = self.module.HermesManager
+        self.hermes._initialized = True
+        self.hermes._enabled = True
+        self.hermes._base_url = "http://hermes.test/v1"
+        self.hermes._api_key = "secret"
+        self.hermes._profile = ""
+        self.hermes._profile_api_keys = {}
+        self.hermes._capabilities_checked = False
+        self.hermes._capabilities = None
+        self.hermes._capabilities_diagnostic = None
+        self.hermes._sessions.clear()
+        self.hermes._hermes_session_ids.clear()
+
+    def _run_probe(self, response, calls=None):
+        calls = calls if calls is not None else []
+
+        def session_factory(**kwargs):
+            return _Session(response, calls=calls, **kwargs)
+
+        with (
+            mock.patch.object(
+                self.module.aiohttp,
+                "ClientSession",
+                side_effect=session_factory,
+            ),
+            mock.patch.object(
+                self.module.aiohttp,
+                "ClientTimeout",
+                return_value=object(),
+            ) as timeout,
+        ):
+            result = asyncio.run(self.hermes.connect())
+        return result, calls, timeout
+
+    def test_capabilities_success_is_recorded_and_only_requested_once(self):
+        body = {
+            "object": "hermes.api_server.capabilities",
+            "platform": "hermes-agent",
+            "features": {"chat_completions_streaming": True},
+            "endpoints": {
+                "chat_completions": {"path": "/v1/chat/completions"},
+                "skills": {"path": "/v1/skills"},
+            },
+        }
+        calls = []
+        response = _Response(200, body)
+
+        def session_factory(**kwargs):
+            return _Session(response, calls=calls, **kwargs)
+
+        with (
+            mock.patch.object(
+                self.module.aiohttp,
+                "ClientSession",
+                side_effect=session_factory,
+            ),
+            mock.patch.object(
+                self.module.aiohttp,
+                "ClientTimeout",
+                return_value=object(),
+            ),
+        ):
+            self.assertTrue(asyncio.run(self.hermes.connect()))
+            self.assertTrue(asyncio.run(self.hermes.connect()))
+
+        self.assertEqual(1, len(calls))
+        self.assertEqual(
+            "http://hermes.test/v1/capabilities",
+            calls[0][1],
+        )
+        self.assertEqual(
+            "Bearer secret",
+            calls[0][2]["headers"]["Authorization"],
+        )
+        self.assertEqual(body, self.hermes.get_capabilities())
+
+    def test_capabilities_probe_is_independent_of_response_mode(self):
+        body = {
+            "object": "hermes.api_server.capabilities",
+            "platform": "hermes-agent",
+            "endpoints": {},
+        }
+        for mode in ("streaming", "complete"):
+            with self.subTest(mode=mode):
+                self.hermes._response_mode = mode
+                self.hermes._capabilities_checked = False
+                self.hermes._capabilities = None
+                result, calls, _timeout = self._run_probe(
+                    _Response(200, body)
+                )
+                self.assertTrue(result)
+                self.assertEqual(1, len(calls))
+                self.assertEqual(
+                    "http://hermes.test/v1/capabilities",
+                    calls[0][1],
+                )
+
+    def test_capabilities_404_is_non_blocking(self):
+        result, _calls, _timeout = self._run_probe(_Response(404))
+        self.assertTrue(result)
+        self.assertIsNone(self.hermes.get_capabilities())
+        self.assertEqual(
+            "unsupported (HTTP 404)",
+            self.hermes._capabilities_diagnostic,
+        )
+
+    def test_capabilities_timeout_is_non_blocking(self):
+        response = _Response(200, enter_error=asyncio.TimeoutError())
+        result, _calls, timeout = self._run_probe(response)
+        self.assertTrue(result)
+        timeout.assert_called_once_with(
+            total=self.hermes.CAPABILITIES_TIMEOUT
+        )
+        self.assertEqual("timeout", self.hermes._capabilities_diagnostic)
+
+    def test_malformed_capabilities_is_non_blocking(self):
+        result, _calls, _timeout = self._run_probe(
+            _Response(200, {"object": "not-hermes"})
+        )
+        self.assertTrue(result)
+        self.assertIsNone(self.hermes.get_capabilities())
+        self.assertEqual(
+            "malformed response",
+            self.hermes._capabilities_diagnostic,
+        )
+
+    def test_old_server_can_chat_after_capabilities_404(self):
+        calls = []
+        get_response = _Response(404)
+        post_response = _Response(
+            200,
+            {
+                "choices": [
+                    {"message": {"content": "兼容回答"}}
+                ]
+            },
+        )
+
+        def session_factory(**kwargs):
+            return _Session(
+                get_response,
+                post_response=post_response,
+                calls=calls,
+                **kwargs,
+            )
+
+        with (
+            mock.patch.object(
+                self.module.aiohttp,
+                "ClientSession",
+                side_effect=session_factory,
+            ),
+            mock.patch.object(
+                self.module.aiohttp,
+                "ClientTimeout",
+                return_value=object(),
+            ),
+        ):
+            self.assertTrue(asyncio.run(self.hermes.connect()))
+            reply = asyncio.run(
+                self.hermes._request_chat_completion("问题")
+            )
+
+        self.assertEqual("兼容回答", reply)
+        self.assertEqual(["GET", "POST"], [call[0] for call in calls])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hermes_progress.py
+++ b/tests/test_hermes_progress.py
@@ -1,0 +1,284 @@
+import unittest
+
+from core.hermes_progress import (
+    HERMES_TOOL_VOICE_STATUS,
+    HermesProgressNarrator,
+    HermesToolProgress,
+)
+
+
+EXPECTED_TOOL_VOICE_STATUS = {
+    "web_search": "正在查找相关资料",
+    "web_extract": "正在读取相关内容",
+    "browser_navigate": "正在浏览相关页面",
+    "browser_click": "正在处理网页操作",
+    "browser_type": "正在处理网页内容",
+    "read_file": "正在读取文件",
+    "write_file": "正在处理文件",
+    "patch": "正在修改内容",
+    "search_files": "正在查找文件",
+    "terminal": "正在执行相关操作",
+    "execute_code": "正在运行程序",
+    "image_generate": "正在生成图片",
+    "video_generate": "正在生成视频",
+    "text_to_speech": "正在生成语音",
+    "vision_analyze": "正在查看图片",
+    "session_search": "正在回顾之前的内容",
+    "skill_view": "正在查看相关技能",
+    "skills_list": "正在查找可用技能",
+    "skill_manage": "正在更新相关技能",
+    "delegate_task": "正在处理子任务",
+    "cronjob": "正在安排任务",
+    "clarify": "正在确认你的需求",
+    "memory": "正在整理相关记忆",
+    "todo": "正在处理任务列表",
+}
+
+
+class HermesProgressNarratorTest(unittest.TestCase):
+    def test_all_curated_builtin_tools_have_exact_voice_mapping(self):
+        self.assertEqual(
+            EXPECTED_TOOL_VOICE_STATUS,
+            HERMES_TOOL_VOICE_STATUS,
+        )
+
+    def test_web_search_uses_curated_status(self):
+        narrator = HermesProgressNarrator("任意问题")
+        narrator.observe(
+            HermesToolProgress(
+                tool="web_search",
+                status="running",
+                tool_call_id="call-1",
+            )
+        )
+        self.assertEqual(
+            ("正在查找相关资料", "tool:web_search"),
+            narrator.next_message(),
+        )
+
+    def test_label_and_machine_arguments_are_never_spoken(self):
+        dangerous_labels = {
+            "execute_code": (
+                "import pandas as pd\n"
+                "file_path='/private/foo.xlsx'"
+            ),
+            "terminal": "rm -rf /something",
+        }
+        for tool, label in dangerous_labels.items():
+            with self.subTest(tool=tool):
+                narrator = HermesProgressNarrator("任意问题")
+                narrator.observe(
+                    HermesToolProgress(
+                        tool=tool,
+                        status="running",
+                        tool_call_id=f"call-{tool}",
+                        label=label,
+                    )
+                )
+                message, _key = narrator.next_message()
+                self.assertEqual(
+                    HERMES_TOOL_VOICE_STATUS[tool],
+                    message,
+                )
+                for unsafe in (
+                    "pandas",
+                    "/private/foo.xlsx",
+                    "rm -rf",
+                    "/something",
+                ):
+                    self.assertNotIn(unsafe, message)
+
+    def test_unknown_plugin_tool_uses_safe_generic_status(self):
+        narrator = HermesProgressNarrator("播放我的私人歌单")
+        narrator.observe(
+            HermesToolProgress(
+                tool="spotify_private_mcp_search",
+                status="running",
+                tool_call_id="call-1",
+                label="search user private playlist",
+            )
+        )
+        message, key = narrator.next_message()
+        self.assertEqual("正在处理，请稍等", message)
+        self.assertEqual("tool:unknown", key)
+        self.assertNotIn("spotify", message.lower())
+        self.assertNotIn("playlist", message.lower())
+
+    def test_no_tool_event_uses_long_wait_generic_status(self):
+        narrator = HermesProgressNarrator("任意问题")
+        self.assertEqual(
+            ("还在为你处理，请稍等", "working"),
+            narrator.next_message(),
+        )
+        self.assertIsNone(narrator.next_message())
+
+    def test_user_query_business_terms_do_not_select_status(self):
+        user_text = (
+            "天气 飞书 Spotify 网易云 显卡价格 Home Assistant"
+        )
+        narrator = HermesProgressNarrator(user_text)
+        self.assertEqual(
+            ("还在为你处理，请稍等", "working"),
+            narrator.next_message(),
+        )
+
+    def test_running_then_completed_uses_generic_completion(self):
+        narrator = HermesProgressNarrator("任意问题")
+        running = HermesToolProgress(
+            tool="write_file",
+            status="running",
+            tool_call_id="call-1",
+        )
+        completed = HermesToolProgress(
+            tool="write_file",
+            status="completed",
+            tool_call_id="call-1",
+        )
+        narrator.observe(running)
+        self.assertEqual(
+            ("正在处理文件", "tool:write_file"),
+            narrator.next_message(),
+        )
+        narrator.observe(completed)
+        self.assertEqual(
+            ("这一步已经完成，正在继续处理。", "organizing"),
+            narrator.next_message(),
+        )
+        self.assertIsNone(narrator.next_message())
+
+    def test_running_then_failed_never_emits_success_summary(self):
+        narrator = HermesProgressNarrator("任意问题")
+        narrator.observe(
+            HermesToolProgress(
+                tool="web_search",
+                status="running",
+                tool_call_id="call-1",
+            )
+        )
+        narrator.next_message()
+        narrator.observe(
+            HermesToolProgress(
+                tool="web_search",
+                status="failed",
+                tool_call_id="call-1",
+            )
+        )
+        self.assertIsNone(narrator.next_message())
+
+    def test_completed_tool_can_summarize_when_another_tool_failed(self):
+        narrator = HermesProgressNarrator("任意问题")
+        for call_id in ("failed-call", "completed-call"):
+            narrator.observe(
+                HermesToolProgress(
+                    tool="web_search",
+                    status="running",
+                    tool_call_id=call_id,
+                )
+            )
+        narrator.next_message()
+        narrator.observe(
+            HermesToolProgress(
+                tool="web_search",
+                status="failed",
+                tool_call_id="failed-call",
+            )
+        )
+        self.assertIsNone(narrator.next_message())
+        narrator.observe(
+            HermesToolProgress(
+                tool="web_search",
+                status="completed",
+                tool_call_id="completed-call",
+            )
+        )
+        self.assertEqual(
+            ("这一步已经完成，正在继续处理。", "organizing"),
+            narrator.next_message(),
+        )
+
+    def test_repeated_same_tool_is_semantically_deduplicated(self):
+        narrator = HermesProgressNarrator("任意问题")
+        for call_id in ("call-1", "call-2"):
+            narrator.observe(
+                HermesToolProgress(
+                    tool="web_search",
+                    status="running",
+                    tool_call_id=call_id,
+                )
+            )
+        self.assertEqual(
+            ("正在查找相关资料", "tool:web_search"),
+            narrator.next_message(),
+        )
+        self.assertIsNone(narrator.next_message())
+
+    def test_different_builtin_tools_can_emit_different_statuses(self):
+        narrator = HermesProgressNarrator("任意问题")
+        narrator.observe(
+            HermesToolProgress(
+                tool="web_search",
+                status="running",
+                tool_call_id="call-1",
+            )
+        )
+        self.assertEqual(
+            ("正在查找相关资料", "tool:web_search"),
+            narrator.next_message(),
+        )
+        narrator.observe(
+            HermesToolProgress(
+                tool="web_extract",
+                status="running",
+                tool_call_id="call-2",
+            )
+        )
+        self.assertEqual(
+            ("正在读取相关内容", "tool:web_extract"),
+            narrator.next_message(),
+        )
+
+    def test_raw_label_never_affects_unknown_tool_tts(self):
+        label = (
+            "https://private.example/path\n"
+            "/private/user/file.json\n"
+            '{"query":"中文私人搜索词"}'
+        )
+        narrator = HermesProgressNarrator("任意问题")
+        narrator.observe(
+            HermesToolProgress(
+                tool="private_mcp_tool",
+                status="running",
+                tool_call_id="call-1",
+                label=label,
+            )
+        )
+        message, _key = narrator.next_message()
+        self.assertEqual("正在处理，请稍等", message)
+        for unsafe in (
+            "private.example",
+            "/private/user/file.json",
+            "query",
+            "中文私人搜索词",
+            "private_mcp_tool",
+        ):
+            self.assertNotIn(unsafe, message)
+
+    def test_technical_log_redacts_urls_and_secrets(self):
+        event = HermesToolProgress(
+            tool="web_search",
+            status="running",
+            tool_call_id="call-1",
+            label=(
+                "fetch https://private.example/path "
+                "Authorization: Bearer-private"
+            ),
+        )
+        label = event.technical_log()["label"]
+        self.assertNotIn("private.example", label)
+        self.assertNotIn("Bearer-private", label)
+        self.assertIn("[URL]", label)
+        self.assertIn("[REDACTED]", label)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_hermes_streaming.py
+++ b/tests/test_hermes_streaming.py
@@ -1,0 +1,995 @@
+import asyncio
+import importlib
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class _Config:
+    def __init__(self, values):
+        self.values = values
+
+    def get_app_config(self, path, default=None):
+        value = self.values
+        for key in path.split("."):
+            if not isinstance(value, dict) or key not in value:
+                return default
+            value = value[key]
+        return value
+
+
+class HermesStreamingTest(unittest.TestCase):
+    def setUp(self):
+        if str(ROOT) not in sys.path:
+            sys.path.insert(0, str(ROOT))
+        server = sys.modules.get("open_xiaoai_server")
+        if server is None:
+            server = types.SimpleNamespace()
+            sys.modules["open_xiaoai_server"] = server
+        if not hasattr(server, "decode_audio"):
+            server.decode_audio = lambda *_args, **_kwargs: b""
+        if not hasattr(server, "begin_playback_session"):
+            server.begin_playback_session = lambda: 1
+
+        module = importlib.import_module("core.hermes_conversation")
+        self.module = module
+        self.streaming_module = importlib.import_module(
+            "core.streaming_conversation"
+        )
+        self.controller = module.HermesConversationController.__new__(
+            module.HermesConversationController
+        )
+        self.controller.config = _Config(
+            {
+                "hermes": {
+                    "streaming": {
+                        "enabled": True,
+                        "sentence_min_chars": 4,
+                        "sentence_max_chars": 80,
+                    },
+                    "progress": {"enabled": False},
+                    "input_mode": "xiaoai_asr",
+                }
+            }
+        )
+        self.controller._playback_token = None
+        self.controller._vad_future = None
+        self.controller._xiaoai_asr_future = None
+        self.controller._loop = None
+        self.controller._stop_recording = mock.AsyncMock()
+        self.controller._start_recording = mock.AsyncMock()
+        self.controller._play_send_sound = mock.AsyncMock()
+
+    def test_start_does_not_rotate_hermes_conversation(self):
+        self.controller.active = False
+        self.controller.backend = types.SimpleNamespace(
+            begin_conversation=mock.Mock()
+        )
+
+        async def scenario():
+            with mock.patch.object(
+                self.module.StreamingConversationController,
+                "start",
+                new=mock.AsyncMock(),
+            ) as parent_start:
+                await self.controller.start()
+                return parent_start
+
+        parent_start = asyncio.run(scenario())
+
+        self.controller.backend.begin_conversation.assert_not_called()
+        parent_start.assert_awaited_once_with()
+
+    def test_interruption_notice_is_not_followed_by_generic_no_reply(self):
+        self.controller._wait_for_xiaoai_asr_text = mock.AsyncMock(
+            return_value="问题"
+        )
+        self.controller._request_backend_turn = mock.AsyncMock(
+            return_value=(None, True)
+        )
+        self.controller._play_notify = mock.AsyncMock()
+        speaker = mock.AsyncMock()
+
+        external_module = importlib.import_module(
+            "core.external_conversation"
+        )
+        with mock.patch.object(
+            external_module,
+            "get_speaker",
+            return_value=speaker,
+        ):
+            result = asyncio.run(
+                self.controller._run_one_turn_with_xiaoai_asr()
+            )
+
+        self.assertEqual("continue", result)
+        speaker.play.assert_not_awaited()
+        self.controller._play_notify.assert_awaited_once_with()
+        self.controller._start_recording.assert_awaited_once_with()
+
+    def test_final_sentence_starts_before_stream_finishes(self):
+        async def scenario():
+            first_spoken = asyncio.Event()
+            release_first = asyncio.Event()
+            stream_completed = False
+            played = []
+
+            async def play(text):
+                played.append(text)
+                if len(played) == 1:
+                    first_spoken.set()
+                    await release_first.wait()
+
+            async def request(
+                _text,
+                *,
+                on_delta,
+                on_tool_progress,
+            ):
+                nonlocal stream_completed
+                del on_tool_progress
+                await on_delta("第一句已经好了。")
+                await first_spoken.wait()
+                self.assertFalse(stream_completed)
+                release_first.set()
+                await on_delta("第二句也好了。")
+                stream_completed = True
+                return "第一句已经好了。第二句也好了。"
+
+            self.controller._play_tts = play
+            self.controller.backend = types.SimpleNamespace(
+                _rule_prompt="",
+                _session_key="agent:hermes:test",
+                request_streaming_chat_completion=request,
+            )
+            result = await self.controller._request_streaming_turn(
+                "问题",
+                play_send_sound=False,
+            )
+            return result, played
+
+        result, played = asyncio.run(scenario())
+
+        self.assertEqual(
+            ("第一句已经好了。第二句也好了。", True),
+            result,
+        )
+        self.assertEqual(
+            ["第一句已经好了。", "第二句也好了。"],
+            played,
+        )
+
+    def test_repeated_tool_events_create_one_rate_limited_progress(self):
+        async def request(
+            _text,
+            *,
+            on_delta,
+            on_tool_progress,
+        ):
+            progress_module = importlib.import_module(
+                "core.hermes_progress"
+            )
+            for call_id in ("call-1", "call-2", "call-3"):
+                await on_tool_progress(
+                    progress_module.HermesToolProgress(
+                        tool="web_search",
+                        status="running",
+                        tool_call_id=call_id,
+                        label="curl https://internal.example",
+                    )
+                )
+            await asyncio.sleep(1.05)
+            await on_delta("这是最终答案。")
+            return "这是最终答案。"
+
+        self.controller.config.values["hermes"]["progress"] = {
+            "enabled": True,
+            "initial_delay": 1,
+            "min_interval": 20,
+            "max_messages": 2,
+        }
+        played = []
+        self.controller._play_tts = mock.AsyncMock(
+            side_effect=lambda text: played.append(text)
+        )
+        self.controller.backend = types.SimpleNamespace(
+            _rule_prompt="",
+            _session_key="agent:hermes:test",
+            request_streaming_chat_completion=request,
+        )
+
+        asyncio.run(
+            self.controller._request_streaming_turn(
+                "查一下最新资料",
+                play_send_sound=False,
+            )
+        )
+
+        self.assertEqual(
+            ["正在查找相关资料", "这是最终答案。"],
+            played,
+        )
+        self.assertNotIn("web_search", "".join(played))
+        self.assertNotIn("http", "".join(played))
+
+    def test_failure_before_spoken_text_does_not_resubmit_turn(self):
+        async def request(
+            _text,
+            *,
+            on_delta,
+            on_tool_progress,
+        ):
+            del on_delta, on_tool_progress
+            raise RuntimeError("stream unavailable")
+
+        played = []
+        self.controller._play_tts = lambda text: _append_async(
+            played,
+            text,
+        )
+        resubmit = mock.AsyncMock(return_value="不应执行的第二次回答。")
+        self.controller.backend = types.SimpleNamespace(
+            _rule_prompt="",
+            _session_key="agent:hermes:test",
+            request_streaming_chat_completion=request,
+            _request_chat_completion=resubmit,
+        )
+
+        result = asyncio.run(
+            self.controller._request_streaming_turn(
+                "问题",
+                play_send_sound=False,
+            )
+        )
+
+        self.assertEqual((None, True), result)
+        self.assertEqual(["回答传输中断了，请再问一次"], played)
+        resubmit.assert_not_awaited()
+
+    def test_failure_after_spoken_text_does_not_replay_answer(self):
+        async def request(
+            _text,
+            *,
+            on_delta,
+            on_tool_progress,
+        ):
+            del on_tool_progress
+            await on_delta("已经播出的第一句。")
+            raise RuntimeError("connection lost")
+
+        played = []
+        self.controller._play_tts = lambda text: _append_async(
+            played,
+            text,
+        )
+        resubmit = mock.AsyncMock(return_value="不应重复的完整回答。")
+        self.controller.backend = types.SimpleNamespace(
+            _rule_prompt="",
+            _session_key="agent:hermes:test",
+            request_streaming_chat_completion=request,
+            _request_chat_completion=resubmit,
+        )
+
+        result = asyncio.run(
+            self.controller._request_streaming_turn(
+                "问题",
+                play_send_sound=False,
+            )
+        )
+
+        self.assertEqual(("已经播出的第一句。", True), result)
+        self.assertEqual(
+            ["已经播出的第一句。", "回答传输中断了，请再问一次"],
+            played,
+        )
+        resubmit.assert_not_awaited()
+
+    def test_tool_progress_then_stream_failure_does_not_resubmit(self):
+        async def request(
+            _text,
+            *,
+            on_delta,
+            on_tool_progress,
+        ):
+            del on_delta
+            progress_module = importlib.import_module(
+                "core.hermes_progress"
+            )
+            await on_tool_progress(
+                progress_module.HermesToolProgress(
+                    tool="web_search",
+                    status="running",
+                    tool_call_id="call-1",
+                )
+            )
+            raise RuntimeError("connection lost after tool side effect")
+
+        played = []
+        self.controller._play_tts = lambda text: _append_async(
+            played,
+            text,
+        )
+        resubmit = mock.AsyncMock(return_value="不应执行")
+        self.controller.backend = types.SimpleNamespace(
+            _rule_prompt="",
+            _session_key="agent:hermes:test",
+            request_streaming_chat_completion=request,
+            _request_chat_completion=resubmit,
+        )
+
+        result = asyncio.run(
+            self.controller._request_streaming_turn(
+                "执行任务",
+                play_send_sound=False,
+            )
+        )
+
+        self.assertEqual((None, True), result)
+        self.assertEqual(["回答传输中断了，请再问一次"], played)
+        resubmit.assert_not_awaited()
+
+    def test_unfinished_delta_is_flushed_without_resubmitting(self):
+        async def request(
+            _text,
+            *,
+            on_delta,
+            on_tool_progress,
+        ):
+            del on_tool_progress
+            await on_delta("尚未成句的片段")
+            raise RuntimeError("connection lost")
+
+        played = []
+        self.controller._play_tts = lambda text: _append_async(
+            played,
+            text,
+        )
+        resubmit = mock.AsyncMock(return_value="不应执行")
+        self.controller.backend = types.SimpleNamespace(
+            _rule_prompt="",
+            _session_key="agent:hermes:test",
+            request_streaming_chat_completion=request,
+            _request_chat_completion=resubmit,
+        )
+
+        result = asyncio.run(
+            self.controller._request_streaming_turn(
+                "问题",
+                play_send_sound=False,
+            )
+        )
+
+        self.assertEqual(("尚未成句的片段", True), result)
+        self.assertEqual(
+            ["尚未成句的片段", "回答传输中断了，请再问一次"],
+            played,
+        )
+        resubmit.assert_not_awaited()
+
+    def test_abort_while_first_of_three_final_chunks_is_playing(self):
+        async def scenario():
+            first_started = asyncio.Event()
+            first_cancelled = asyncio.Event()
+            keep_stream_open = asyncio.Event()
+            played = []
+            speaker = mock.AsyncMock()
+
+            async def play(text):
+                played.append(text)
+                if len(played) == 1:
+                    first_started.set()
+                    try:
+                        await asyncio.Future()
+                    except asyncio.CancelledError:
+                        first_cancelled.set()
+                        raise
+
+            async def request(
+                _text,
+                *,
+                on_delta,
+                on_tool_progress,
+            ):
+                del on_tool_progress
+                await on_delta("第一句已经就绪。第二句已经就绪。第三句已经就绪。")
+                await keep_stream_open.wait()
+                return "不应完成"
+
+            self.controller.active = True
+            self.controller._play_tts = play
+            self.controller.backend = types.SimpleNamespace(
+                _rule_prompt="",
+                _session_key="agent:hermes:test",
+                request_streaming_chat_completion=request,
+            )
+            baseline = set(asyncio.all_tasks())
+            with mock.patch.object(
+                self.streaming_module,
+                "get_speaker",
+                return_value=speaker,
+            ):
+                task = asyncio.create_task(
+                    self.controller._request_streaming_turn(
+                        "问题",
+                        play_send_sound=False,
+                    )
+                )
+                await first_started.wait()
+                self.controller.stop()
+                self.controller.stop()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+                await asyncio.sleep(0)
+                leftovers = [
+                    item
+                    for item in asyncio.all_tasks() - baseline
+                    if not item.done()
+                ]
+            return played, first_cancelled.is_set(), leftovers, speaker
+
+        played, first_cancelled, leftovers, speaker = asyncio.run(scenario())
+        self.assertEqual(["第一句已经就绪。"], played)
+        self.assertTrue(first_cancelled)
+        self.assertEqual([], leftovers)
+        speaker.stop_device_audio.assert_awaited_once()
+        self.controller._start_recording.assert_awaited_once()
+
+    def test_abort_while_send_sound_blocks_reclaims_all_children(self):
+        async def scenario():
+            send_sound_started = asyncio.Event()
+            stream_started = asyncio.Event()
+            stream_cancelled = asyncio.Event()
+            speaker = mock.AsyncMock()
+
+            async def send_sound():
+                send_sound_started.set()
+                await asyncio.Future()
+
+            async def request(
+                _text,
+                *,
+                on_delta,
+                on_tool_progress,
+            ):
+                del on_delta, on_tool_progress
+                stream_started.set()
+                try:
+                    await asyncio.Future()
+                except asyncio.CancelledError:
+                    stream_cancelled.set()
+                    raise
+
+            self.controller._play_send_sound = send_sound
+            self.controller._play_tts = mock.AsyncMock()
+            self.controller.backend = types.SimpleNamespace(
+                _rule_prompt="",
+                _session_key="agent:hermes:test",
+                request_streaming_chat_completion=request,
+            )
+            baseline = set(asyncio.all_tasks())
+            with mock.patch.object(
+                self.streaming_module,
+                "get_speaker",
+                return_value=speaker,
+            ):
+                task = asyncio.create_task(
+                    self.controller._request_streaming_turn(
+                        "问题",
+                        play_send_sound=True,
+                    )
+                )
+                await send_sound_started.wait()
+                await stream_started.wait()
+                task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+                await asyncio.sleep(0)
+                leftovers = [
+                    item
+                    for item in asyncio.all_tasks() - baseline
+                    if not item.done()
+                ]
+            return stream_cancelled.is_set(), leftovers, speaker
+
+        stream_cancelled, leftovers, speaker = asyncio.run(scenario())
+        self.assertTrue(stream_cancelled)
+        self.assertEqual([], leftovers)
+        speaker.stop_device_audio.assert_awaited_once()
+        self.controller._start_recording.assert_awaited_once()
+
+    def test_send_sound_exception_aborts_children_and_restores_recording(self):
+        async def scenario():
+            stream_cancelled = asyncio.Event()
+            speaker = mock.AsyncMock()
+
+            async def request(
+                _text,
+                *,
+                on_delta,
+                on_tool_progress,
+            ):
+                del on_delta, on_tool_progress
+                try:
+                    await asyncio.Future()
+                except asyncio.CancelledError:
+                    stream_cancelled.set()
+                    raise
+
+            self.controller._play_send_sound = mock.AsyncMock(
+                side_effect=RuntimeError("beep failed")
+            )
+            self.controller._play_tts = mock.AsyncMock()
+            self.controller.backend = types.SimpleNamespace(
+                _rule_prompt="",
+                _session_key="agent:hermes:test",
+                request_streaming_chat_completion=request,
+            )
+            baseline = set(asyncio.all_tasks())
+            with mock.patch.object(
+                self.streaming_module,
+                "get_speaker",
+                return_value=speaker,
+            ):
+                with self.assertRaisesRegex(RuntimeError, "beep failed"):
+                    await self.controller._request_streaming_turn(
+                        "问题",
+                        play_send_sound=True,
+                    )
+                await asyncio.sleep(0)
+                leftovers = [
+                    item
+                    for item in asyncio.all_tasks() - baseline
+                    if not item.done()
+                ]
+            return stream_cancelled.is_set(), leftovers, speaker
+
+        stream_cancelled, leftovers, speaker = asyncio.run(scenario())
+        self.assertTrue(stream_cancelled)
+        self.assertEqual([], leftovers)
+        speaker.stop_device_audio.assert_awaited_once()
+        self.controller._start_recording.assert_awaited_once()
+
+    def test_abort_unfinished_delta_never_plays_it(self):
+        async def scenario():
+            delta_received = asyncio.Event()
+            speaker = mock.AsyncMock()
+            played = []
+
+            async def request(
+                _text,
+                *,
+                on_delta,
+                on_tool_progress,
+            ):
+                del on_tool_progress
+                await on_delta("短片段")
+                delta_received.set()
+                await asyncio.Future()
+
+            self.controller._play_tts = lambda text: _append_async(
+                played,
+                text,
+            )
+            self.controller.backend = types.SimpleNamespace(
+                _rule_prompt="",
+                _session_key="agent:hermes:test",
+                request_streaming_chat_completion=request,
+            )
+            with mock.patch.object(
+                self.streaming_module,
+                "get_speaker",
+                return_value=speaker,
+            ):
+                task = asyncio.create_task(
+                    self.controller._request_streaming_turn(
+                        "问题",
+                        play_send_sound=False,
+                    )
+                )
+                await delta_received.wait()
+                task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+            return played
+
+        self.assertEqual([], asyncio.run(scenario()))
+
+    def test_abort_progress_in_playback_never_continues_to_final(self):
+        async def scenario():
+            progress_started = asyncio.Event()
+            progress_cancelled = asyncio.Event()
+            speaker = mock.AsyncMock()
+            original_wait_for = asyncio.wait_for
+            initial_timeout_injected = False
+            played = []
+
+            async def controlled_wait_for(awaitable, timeout):
+                nonlocal initial_timeout_injected
+                if not initial_timeout_injected:
+                    initial_timeout_injected = True
+                    awaitable.close()
+                    raise asyncio.TimeoutError
+                return await original_wait_for(awaitable, timeout)
+
+            async def play(text):
+                played.append(text)
+                progress_started.set()
+                try:
+                    await asyncio.Future()
+                except asyncio.CancelledError:
+                    progress_cancelled.set()
+                    raise
+
+            async def request(
+                _text,
+                *,
+                on_delta,
+                on_tool_progress,
+            ):
+                del on_delta
+                progress_module = importlib.import_module(
+                    "core.hermes_progress"
+                )
+                await on_tool_progress(
+                    progress_module.HermesToolProgress(
+                        tool="web_search",
+                        status="running",
+                        tool_call_id="call-1",
+                    )
+                )
+                await asyncio.Future()
+
+            self.controller.config.values["hermes"]["progress"] = {
+                "enabled": True,
+                "initial_delay": 1,
+                "min_interval": 20,
+                "max_messages": 1,
+            }
+            self.controller._play_tts = play
+            self.controller.backend = types.SimpleNamespace(
+                _rule_prompt="",
+                _session_key="agent:hermes:test",
+                request_streaming_chat_completion=request,
+            )
+            with (
+                mock.patch.object(
+                    self.streaming_module,
+                    "get_speaker",
+                    return_value=speaker,
+                ),
+                mock.patch.object(
+                    self.streaming_module.asyncio,
+                    "wait_for",
+                    side_effect=controlled_wait_for,
+                ),
+            ):
+                task = asyncio.create_task(
+                    self.controller._request_streaming_turn(
+                        "查资料",
+                        play_send_sound=False,
+                    )
+                )
+                await progress_started.wait()
+                task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await task
+            return played, progress_cancelled.is_set()
+
+        played, progress_cancelled = asyncio.run(scenario())
+        # 这个受控竞态在 tool event 到达前先触发 long-wait，
+        # 因而只能使用“尚无真实工具事件”的通用提示。
+        self.assertEqual(["还在为你处理，请稍等"], played)
+        self.assertTrue(progress_cancelled)
+
+    def test_old_aborted_turn_cannot_speak_after_new_turn_starts(self):
+        async def scenario():
+            old_started = asyncio.Event()
+            speaker = mock.AsyncMock()
+            played = []
+
+            async def old_play(text):
+                played.append(("old", text))
+                old_started.set()
+                await asyncio.Future()
+
+            async def old_request(
+                _text,
+                *,
+                on_delta,
+                on_tool_progress,
+            ):
+                del on_tool_progress
+                await on_delta("旧会话第一句。旧会话第二句。")
+                await asyncio.Future()
+
+            self.controller._play_tts = old_play
+            self.controller.backend = types.SimpleNamespace(
+                _rule_prompt="",
+                _session_key="agent:hermes:old",
+                request_streaming_chat_completion=old_request,
+            )
+            with mock.patch.object(
+                self.streaming_module,
+                "get_speaker",
+                return_value=speaker,
+            ):
+                old_task = asyncio.create_task(
+                    self.controller._request_streaming_turn(
+                        "旧问题",
+                        play_send_sound=False,
+                    )
+                )
+                await old_started.wait()
+                old_task.cancel()
+                with self.assertRaises(asyncio.CancelledError):
+                    await old_task
+
+                new_controller = self.module.HermesConversationController.__new__(
+                    self.module.HermesConversationController
+                )
+                new_controller.config = self.controller.config
+                new_controller._playback_token = None
+                new_controller._stop_recording = mock.AsyncMock()
+                new_controller._start_recording = mock.AsyncMock()
+                new_controller._play_send_sound = mock.AsyncMock()
+                new_controller._play_tts = lambda text: _append_async(
+                    played,
+                    ("new", text),
+                )
+
+                async def new_request(
+                    _text,
+                    *,
+                    on_delta,
+                    on_tool_progress,
+                ):
+                    del on_tool_progress
+                    await on_delta("新会话回答。")
+                    return "新会话回答。"
+
+                new_controller.backend = types.SimpleNamespace(
+                    _rule_prompt="",
+                    _session_key="agent:hermes:new",
+                    request_streaming_chat_completion=new_request,
+                )
+                await new_controller._request_streaming_turn(
+                    "新问题",
+                    play_send_sound=False,
+                )
+                await asyncio.sleep(0)
+            return played
+
+        self.assertEqual(
+            [
+                ("old", "旧会话第一句。"),
+                ("new", "新会话回答。"),
+            ],
+            asyncio.run(scenario()),
+        )
+
+    def test_mode_like_phrases_are_forwarded_unchanged(self):
+        complete = mock.AsyncMock(return_value="回答")
+        self.controller.backend = types.SimpleNamespace(
+            _rule_prompt="",
+            get_response_mode=lambda: "complete",
+            _request_chat_completion=complete,
+        )
+
+        result = asyncio.run(
+            self.controller._request_backend_turn(
+                "详细查一下，不要简单说",
+                play_send_sound=False,
+            )
+        )
+
+        self.assertEqual(("回答", False), result)
+        complete.assert_awaited_once_with(
+            "详细查一下，不要简单说"
+        )
+
+    def test_streaming_mode_uses_sse_and_never_calls_complete(self):
+        async def stream(
+            _text,
+            *,
+            on_delta,
+            on_tool_progress,
+        ):
+            del on_tool_progress
+            await on_delta("流式回答完成。")
+            return "流式回答完成。"
+
+        complete = mock.AsyncMock(return_value="不应调用")
+        played = []
+        self.controller._play_tts = lambda text: _append_async(
+            played,
+            text,
+        )
+        self.controller.backend = types.SimpleNamespace(
+            _rule_prompt="",
+            _session_key="agent:hermes:test",
+            get_response_mode=lambda: "streaming",
+            request_streaming_chat_completion=stream,
+            _request_chat_completion=complete,
+        )
+
+        result = asyncio.run(
+            self.controller._request_backend_turn(
+                "问题",
+                play_send_sound=False,
+            )
+        )
+
+        self.assertEqual(("流式回答完成。", True), result)
+        self.assertEqual(["流式回答完成。"], played)
+        complete.assert_not_awaited()
+
+    def test_complete_mode_skips_stream_queue_and_plays_once(self):
+        complete = mock.AsyncMock(return_value="完整回答")
+        stream = mock.AsyncMock(return_value="不应调用")
+        self.controller.backend = types.SimpleNamespace(
+            _rule_prompt="",
+            get_response_mode=lambda: "complete",
+            _request_chat_completion=complete,
+            request_streaming_chat_completion=stream,
+        )
+        self.controller._wait_for_xiaoai_asr_text = mock.AsyncMock(
+            return_value="问题"
+        )
+        self.controller._play_tts = mock.AsyncMock()
+        self.controller._play_notify = mock.AsyncMock()
+
+        with mock.patch.object(
+            self.streaming_module,
+            "SequentialSpeechQueue",
+            side_effect=AssertionError("complete must not create queue"),
+        ):
+            result = asyncio.run(
+                self.controller._run_one_turn_with_xiaoai_asr()
+            )
+
+        self.assertEqual("continue", result)
+        complete.assert_awaited_once_with("问题")
+        stream.assert_not_awaited()
+        self.controller._play_tts.assert_awaited_once_with("完整回答")
+
+    def test_complete_failure_is_not_retried_as_streaming(self):
+        complete = mock.AsyncMock(
+            side_effect=RuntimeError("request failed")
+        )
+        stream = mock.AsyncMock(return_value="不应调用")
+        self.controller.backend = types.SimpleNamespace(
+            _rule_prompt="",
+            get_response_mode=lambda: "complete",
+            _request_chat_completion=complete,
+            request_streaming_chat_completion=stream,
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "request failed"):
+            asyncio.run(
+                self.controller._request_backend_turn(
+                    "问题",
+                    play_send_sound=False,
+                )
+            )
+
+        complete.assert_awaited_once_with("问题")
+        stream.assert_not_awaited()
+
+    def test_complete_http_wait_is_cancelled_by_stop(self):
+        async def scenario():
+            request_started = asyncio.Event()
+            request_cancelled = asyncio.Event()
+
+            async def complete(_text):
+                request_started.set()
+                try:
+                    await asyncio.Future()
+                except asyncio.CancelledError:
+                    request_cancelled.set()
+                    raise
+
+            self.controller.config.values["hermes"]["input_mode"] = (
+                "local_asr"
+            )
+            self.controller.active = True
+            self.controller._loop = asyncio.get_running_loop()
+            self.controller.backend = types.SimpleNamespace(
+                _rule_prompt="",
+                get_response_mode=lambda: "complete",
+                _request_chat_completion=complete,
+            )
+            turn = asyncio.create_task(
+                self.controller._request_backend_turn(
+                    "问题",
+                    play_send_sound=False,
+                )
+            )
+            await request_started.wait()
+            self.controller.stop()
+            with self.assertRaises(asyncio.CancelledError):
+                await turn
+            return request_cancelled.is_set()
+
+        self.assertTrue(asyncio.run(scenario()))
+
+    def test_complete_tts_playback_token_is_stopped_without_replay(self):
+        async def scenario():
+            playback_started = asyncio.Event()
+            release_playback = asyncio.Event()
+            calls = []
+
+            async def play_response(text, **_kwargs):
+                calls.append(text)
+                playback_started.set()
+                await release_playback.wait()
+                return True
+
+            self.controller.config.values["hermes"]["input_mode"] = (
+                "local_asr"
+            )
+            self.controller.active = True
+            self.controller._loop = asyncio.get_running_loop()
+            self.controller.backend = types.SimpleNamespace(
+                _play_response_with_tts=play_response,
+                get_tts_speaker_for_session_key=lambda: "xiaoai",
+            )
+            external_module = importlib.import_module(
+                "core.external_conversation"
+            )
+            with (
+                mock.patch.object(
+                    self.module.open_xiaoai_server,
+                    "begin_playback_session",
+                    return_value=73,
+                ),
+                mock.patch.object(
+                    external_module.open_xiaoai_server,
+                    "stop_tts_playback",
+                    create=True,
+                ) as stop_playback,
+            ):
+                playback = asyncio.create_task(
+                    self.controller._play_tts("完整回答")
+                )
+                await playback_started.wait()
+                self.controller.stop()
+                stop_playback.assert_called_once_with(73)
+                release_playback.set()
+                await playback
+            return calls
+
+        self.assertEqual(["完整回答"], asyncio.run(scenario()))
+
+    def test_failed_tts_does_not_retry_native_playback(self):
+        backend = types.SimpleNamespace(
+            _play_response_with_tts=mock.AsyncMock(
+                return_value=False
+            ),
+            get_tts_speaker_for_session_key=mock.Mock(
+                return_value="xiaoai"
+            ),
+        )
+        self.controller.backend = backend
+
+        async def scenario():
+            with self.assertRaisesRegex(
+                RuntimeError,
+                "did not complete",
+            ):
+                await self.controller._play_tts("播放失败")
+
+        asyncio.run(scenario())
+        self.assertIsNone(self.controller._playback_token)
+
+
+async def _append_async(items, value):
+    items.append(value)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_openai_stream.py
+++ b/tests/test_openai_stream.py
@@ -1,0 +1,246 @@
+import asyncio
+import importlib
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+
+
+class OpenAIStreamHelpersTest(unittest.TestCase):
+    def setUp(self):
+        if str(ROOT) not in sys.path:
+            sys.path.insert(0, str(ROOT))
+        self.module = importlib.import_module("core.openai_stream")
+
+    def test_sse_decoder_handles_network_and_utf8_boundaries(self):
+        decoder = self.module.SSEDecoder()
+        payload = (
+            'event: custom.progress\n'
+            'data: {"status":"running"}\n\n'
+            'data: {"choices":[{"delta":{"content":"你好。"},'
+            '"finish_reason":null}]}\n\n'
+        )
+        encoded = payload.encode("utf-8")
+        utf8_decoder = __import__("codecs").getincrementaldecoder("utf-8")()
+        events = []
+        for chunk in (encoded[:13], encoded[13:61], encoded[61:77], encoded[77:]):
+            events.extend(decoder.feed(utf8_decoder.decode(chunk)))
+        events.extend(
+            decoder.feed(
+                utf8_decoder.decode(b"", final=True),
+                final=True,
+            )
+        )
+
+        self.assertEqual(
+            ["custom.progress", "message"],
+            [event.event for event in events],
+        )
+        delta, finish_reason = self.module.extract_openai_delta(
+            events[1].data
+        )
+        self.assertEqual("你好。", delta)
+        self.assertIsNone(finish_reason)
+
+    def test_sentence_chunker_flushes_and_bounds_long_text(self):
+        chunker = self.module.SentenceChunker(
+            min_chars=4,
+            max_chars=8,
+        )
+
+        chunks = chunker.feed("第一句话。第二句话还没有结束")
+        chunks.extend(chunker.feed("。尾巴", final=True))
+
+        self.assertEqual("第一句话。", chunks[0])
+        self.assertEqual(
+            "第一句话。第二句话还没有结束。尾巴",
+            "".join(chunks),
+        )
+        self.assertTrue(all(len(chunk) <= 8 for chunk in chunks))
+
+    def test_transport_forwards_named_events_without_interpreting_them(self):
+        payload = (
+            "event: vendor.progress\n"
+            'data: {"internal":"opaque"}\n\n'
+            'data: {"choices":[{"delta":{"content":"最终答案。"},'
+            '"finish_reason":"stop"}]}\n\n'
+            "data: [DONE]\n\n"
+        ).encode()
+        chunks = [payload[:41], payload[41:83], payload[83:]]
+
+        class FakeContent:
+            async def iter_any(self):
+                for chunk in chunks:
+                    yield chunk
+
+        class FakeResponse:
+            status = 200
+            headers = {"Content-Type": "text/event-stream"}
+            content = FakeContent()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+        class FakeSession:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+            def post(self, *_args, **_kwargs):
+                return FakeResponse()
+
+        manager = types.SimpleNamespace(
+            _initialized=True,
+            _enabled=True,
+            _session_key="agent:test",
+            _sessions={},
+            _model="model",
+            _extra_body={},
+            _temperature=None,
+            _max_tokens=None,
+            _timeout=10,
+            _build_messages=lambda history, text: [
+                {"role": "user", "content": text}
+            ],
+            _chat_completions_url=lambda: "http://example.test/v1/chat/completions",
+            _headers=lambda: {"Content-Type": "application/json"},
+            _capture_response_headers=mock.Mock(),
+            _append_history=lambda history, text, response: history.extend(
+                [
+                    {"role": "user", "content": text},
+                    {"role": "assistant", "content": response},
+                ]
+            ),
+        )
+        deltas = []
+        events = []
+
+        async def scenario():
+            with (
+                mock.patch.object(
+                    self.module.aiohttp,
+                    "ClientSession",
+                    FakeSession,
+                ),
+                mock.patch.object(
+                    self.module.aiohttp,
+                    "ClientTimeout",
+                    lambda **_kwargs: object(),
+                ),
+                mock.patch.object(self.module.logger, "ai_response"),
+            ):
+                return await self.module.stream_openai_chat_completion(
+                    manager,
+                    "问题",
+                    on_delta=lambda value: deltas.append(value),
+                    on_event=lambda event: events.append(event),
+                    log_name="Test Stream",
+                )
+
+        self.assertEqual("最终答案。", asyncio.run(scenario()))
+        self.assertEqual(["最终答案。"], deltas)
+        self.assertEqual(["vendor.progress"], [event.event for event in events])
+        self.assertEqual('{"internal":"opaque"}', events[0].data)
+        manager._capture_response_headers.assert_called_once_with(
+            FakeResponse.headers,
+            session_key="agent:test",
+        )
+
+    def test_interrupted_stream_does_not_write_partial_history(self):
+        payload = (
+            'data: {"choices":[{"delta":{"content":"部分回答"},'
+            '"finish_reason":null}]}\n\n'
+        ).encode()
+
+        class FakeContent:
+            async def iter_any(self):
+                yield payload
+                raise RuntimeError("connection lost")
+
+        class FakeResponse:
+            status = 200
+            headers = {"Content-Type": "text/event-stream"}
+            content = FakeContent()
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+        class FakeSession:
+            def __init__(self, **_kwargs):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_args):
+                return False
+
+            def post(self, *_args, **_kwargs):
+                return FakeResponse()
+
+        manager = types.SimpleNamespace(
+            _initialized=True,
+            _enabled=True,
+            _session_key="agent:test",
+            _sessions={},
+            _model="model",
+            _extra_body={},
+            _temperature=None,
+            _max_tokens=None,
+            _timeout=10,
+            _build_messages=lambda history, text: [
+                {"role": "user", "content": text}
+            ],
+            _chat_completions_url=lambda: (
+                "http://example.test/v1/chat/completions"
+            ),
+            _headers=lambda: {"Content-Type": "application/json"},
+            _capture_response_headers=mock.Mock(),
+            _append_history=mock.Mock(),
+        )
+        deltas = []
+
+        async def scenario():
+            with (
+                mock.patch.object(
+                    self.module.aiohttp,
+                    "ClientSession",
+                    FakeSession,
+                ),
+                mock.patch.object(
+                    self.module.aiohttp,
+                    "ClientTimeout",
+                    lambda **_kwargs: object(),
+                ),
+            ):
+                await self.module.stream_openai_chat_completion(
+                    manager,
+                    "问题",
+                    on_delta=lambda value: deltas.append(value),
+                )
+
+        with self.assertRaisesRegex(RuntimeError, "connection lost"):
+            asyncio.run(scenario())
+
+        self.assertEqual(["部分回答"], deltas)
+        manager._append_history.assert_not_called()
+        self.assertEqual({"agent:test": []}, manager._sessions)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_speech_queue.py
+++ b/tests/test_speech_queue.py
@@ -1,0 +1,155 @@
+import asyncio
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.speech_queue import SequentialSpeechQueue
+
+
+class SequentialSpeechQueueRaceTest(unittest.TestCase):
+    def test_final_removes_progress_that_has_not_started(self):
+        async def scenario():
+            queue = SequentialSpeechQueue()
+            await queue.put_progress("正在查看天气", key="weather")
+            removed = await queue.mark_final_started()
+            rejected = await queue.put_progress(
+                "还在处理",
+                key="working",
+            )
+            await queue.put_final("最终答案")
+            await queue.close()
+            item = await queue.get()
+            await queue.finish(item)
+            return removed, rejected, item, await queue.get()
+
+        removed, rejected, item, end = asyncio.run(scenario())
+        self.assertEqual(1, removed)
+        self.assertFalse(rejected)
+        self.assertEqual(("final", "最终答案"), (item.kind, item.text))
+        self.assertIsNone(end)
+
+    def test_progress_already_playing_finishes_before_final(self):
+        async def scenario():
+            queue = SequentialSpeechQueue()
+            progress_started = asyncio.Event()
+            release_progress = asyncio.Event()
+            active = 0
+            max_active = 0
+            played = []
+
+            async def play(item):
+                nonlocal active, max_active
+                active += 1
+                max_active = max(max_active, active)
+                played.append(("start", item.kind))
+                if item.kind == "progress":
+                    progress_started.set()
+                    await release_progress.wait()
+                played.append(("end", item.kind))
+                active -= 1
+
+            async def worker():
+                while True:
+                    item = await queue.get()
+                    if item is None:
+                        return
+                    try:
+                        await play(item)
+                    finally:
+                        await queue.finish(item)
+
+            task = asyncio.create_task(worker())
+            await queue.put_progress("正在查看天气", key="weather")
+            await progress_started.wait()
+            await queue.put_final("最终答案")
+            await asyncio.sleep(0)
+            self.assertNotIn(("start", "final"), played)
+            release_progress.set()
+            await queue.close()
+            await task
+            return max_active, played
+
+        max_active, played = asyncio.run(scenario())
+        self.assertEqual(1, max_active)
+        self.assertEqual(
+            [
+                ("start", "progress"),
+                ("end", "progress"),
+                ("start", "final"),
+                ("end", "final"),
+            ],
+            played,
+        )
+
+    def test_progress_is_deduplicated_and_coalesced(self):
+        async def scenario():
+            queue = SequentialSpeechQueue()
+            first = await queue.put_progress(
+                "正在查资料",
+                key="research",
+            )
+            duplicate = await queue.put_progress(
+                "仍在查资料",
+                key="research",
+            )
+            newer = await queue.put_progress(
+                "正在整理",
+                key="organizing",
+            )
+            await queue.close()
+            item = await queue.get()
+            await queue.finish(item)
+            return first, duplicate, newer, item, await queue.get()
+
+        first, duplicate, newer, item, end = asyncio.run(scenario())
+        self.assertTrue(first)
+        self.assertFalse(duplicate)
+        self.assertTrue(newer)
+        self.assertEqual("organizing", item.key)
+        self.assertIsNone(end)
+
+    def test_abort_discards_all_queued_items_and_rejects_new_work(self):
+        async def scenario():
+            queue = SequentialSpeechQueue()
+            await queue.put_final("第一句")
+            first = await queue.get()
+            await queue.put_final("第二句")
+            await queue.put_final("第三句")
+
+            removed = await queue.abort()
+            repeated = await queue.abort()
+            rejected_final = await queue.put_final("第四句")
+            rejected_progress = await queue.put_progress(
+                "仍在处理",
+                key="working",
+            )
+            await queue.finish(first)
+            return (
+                removed,
+                repeated,
+                rejected_final,
+                rejected_progress,
+                queue.aborted,
+                await queue.get(),
+            )
+
+        result = asyncio.run(scenario())
+        self.assertEqual((2, 0, False, False, True, None), result)
+
+    def test_abort_drops_progress_before_worker_can_take_it(self):
+        async def scenario():
+            queue = SequentialSpeechQueue()
+            await queue.put_progress("正在处理", key="working")
+            removed = await queue.abort()
+            return removed, await queue.get()
+
+        self.assertEqual((1, None), asyncio.run(scenario()))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_wakeup_keywords.py
+++ b/tests/test_wakeup_keywords.py
@@ -37,15 +37,43 @@ class WakeupKeywordStartupTest(unittest.TestCase):
         self.assertTrue(should_run)
         self.assertEqual(reason, "")
 
+    def test_keyword_generation_enabled_for_hermes(self):
+        spec = importlib.util.spec_from_file_location(
+            "kws_keywords_for_hermes_test",
+            ROOT / "core/services/audio/kws/keywords.py",
+        )
+        keywords = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(keywords)
+
+        with mock.patch.dict(
+            os.environ,
+            {
+                "XIAOZHI_ENABLE": "",
+                "OPENCLAW_ENABLE": "",
+                "OPENCLAW_ENABLED": "",
+                "OPENAI_ENABLE": "",
+                "HERMES_ENABLE": "1",
+                "QWENPAW_ENABLE": "",
+            },
+            clear=False,
+        ):
+            should_run, reason = keywords.should_generate_keywords()
+
+        self.assertTrue(should_run)
+        self.assertEqual(reason, "")
+
     def test_startup_entrypoints_prepare_keywords_for_openai(self):
         start_sh = (ROOT / "scripts/start.sh").read_text(encoding="utf8")
         dockerfile = (ROOT / "Dockerfile").read_text(encoding="utf8")
 
         self.assertIn("OPENAI_ENABLE_VALUE", start_sh)
+        self.assertIn("HERMES_ENABLE_VALUE", start_sh)
         self.assertIn("QWENPAW_ENABLE_VALUE", start_sh)
         self.assertIn('[[ "$OPENAI_ENABLE_VALUE" =~ ^(1|true|yes)$ ]]', start_sh)
+        self.assertIn('[[ "$HERMES_ENABLE_VALUE" =~ ^(1|true|yes)$ ]]', start_sh)
         self.assertIn('[[ "$QWENPAW_ENABLE_VALUE" =~ ^(1|true|yes)$ ]]', start_sh)
         self.assertIn('${OPENAI_ENABLE:-}', dockerfile)
+        self.assertIn('${HERMES_ENABLE:-}', dockerfile)
         self.assertIn('${QWENPAW_ENABLE:-}', dockerfile)
         self.assertIn('python core/services/audio/kws/keywords.py', dockerfile)
 
@@ -160,6 +188,125 @@ class XiaoAIWakeupKeywordTest(unittest.TestCase):
                 ("你好小黑", "kws"),
             ],
         )
+
+
+class WakeupSessionCleanupTest(unittest.TestCase):
+    def test_reset_waits_for_cancelled_hermes_session_cleanup(self):
+        async def scenario():
+            wakeup_module = importlib.import_module("core.wakeup_session")
+            manager = wakeup_module.WakeupSessionManager.__new__(
+                wakeup_module.WakeupSessionManager
+            )
+            manager._openclaw_controller = None
+            manager._openclaw_task = None
+            manager._openai_controller = None
+            manager._openai_task = None
+            manager._qwenpaw_controller = None
+            manager._qwenpaw_task = None
+            manager._xiaozhi_future = None
+            manager._stop_device_playback = mock.AsyncMock()
+
+            cleanup_started = asyncio.Event()
+            allow_cleanup = asyncio.Event()
+            cleanup_finished = asyncio.Event()
+
+            async def old_hermes_session():
+                try:
+                    await asyncio.Future()
+                except asyncio.CancelledError:
+                    cleanup_started.set()
+                    await allow_cleanup.wait()
+                    cleanup_finished.set()
+                    raise
+
+            controller = mock.Mock()
+            controller.is_active.return_value = True
+            manager._hermes_controller = controller
+            manager._hermes_task = asyncio.create_task(
+                old_hermes_session()
+            )
+
+            xiaoai_stub = types.SimpleNamespace(
+                XiaoAI=types.SimpleNamespace(stop_conversation=mock.Mock())
+            )
+            with (
+                mock.patch.dict(
+                    sys.modules,
+                    {"core.xiaoai": xiaoai_stub},
+                ),
+                mock.patch(
+                    "core.ref.get_xiaozhi",
+                    return_value=None,
+                ),
+            ):
+                reset_task = asyncio.create_task(
+                    manager.reset_all_sessions()
+                )
+                await cleanup_started.wait()
+                self.assertFalse(reset_task.done())
+                self.assertFalse(cleanup_finished.is_set())
+                manager._stop_device_playback.assert_not_awaited()
+                allow_cleanup.set()
+                await reset_task
+
+            return manager, controller, cleanup_finished.is_set()
+
+        manager, controller, cleanup_finished = asyncio.run(scenario())
+        self.assertTrue(cleanup_finished)
+        controller.stop.assert_called_once_with()
+        manager._stop_device_playback.assert_awaited_once_with()
+
+    def test_old_hermes_finally_does_not_clear_new_session_owner(self):
+        async def scenario():
+            wakeup_module = importlib.import_module("core.wakeup_session")
+            manager = wakeup_module.WakeupSessionManager.__new__(
+                wakeup_module.WakeupSessionManager
+            )
+            manager._hermes_controller = None
+            manager._hermes_task = None
+
+            old_started = asyncio.Event()
+
+            class OldController:
+                async def start(self):
+                    old_started.set()
+                    await asyncio.Future()
+
+            hermes_conversation_stub = types.SimpleNamespace(
+                HermesConversationController=OldController
+            )
+            with (
+                mock.patch.dict(
+                    sys.modules,
+                    {
+                        "core.hermes_conversation": (
+                            hermes_conversation_stub
+                        )
+                    },
+                ),
+                mock.patch.object(
+                    wakeup_module,
+                    "get_kws",
+                    return_value=None,
+                ),
+            ):
+                old_wakeup = asyncio.create_task(
+                    manager._start_hermes_conversation()
+                )
+                await old_started.wait()
+                new_controller = object()
+                new_task = asyncio.create_task(asyncio.sleep(0))
+                manager._hermes_controller = new_controller
+                manager._hermes_task = new_task
+                old_wakeup.cancel()
+                await old_wakeup
+                await new_task
+
+            return manager, new_controller, new_task
+
+        manager, new_controller, new_task = asyncio.run(scenario())
+        self.assertIs(manager._hermes_controller, new_controller)
+        self.assertIs(manager._hermes_task, new_task)
 
 
 if __name__ == "__main__":

--- a/tests/test_xiaoai_tts_skill.py
+++ b/tests/test_xiaoai_tts_skill.py
@@ -1,0 +1,82 @@
+import importlib.util
+import io
+import sys
+import unittest
+from contextlib import redirect_stderr
+from pathlib import Path
+from unittest import mock
+
+
+ROOT = Path(__file__).resolve().parents[1]
+SKILL_DIR = ROOT / "skills" / "xiaoai-tts"
+
+
+def _load_script(name):
+    scripts_dir = SKILL_DIR / "scripts"
+    if str(scripts_dir) not in sys.path:
+        sys.path.insert(0, str(scripts_dir))
+    spec = importlib.util.spec_from_file_location(name, scripts_dir / f"{name}.py")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+class XiaoAITTSSkillTest(unittest.TestCase):
+    def test_skill_declares_hermes_path_and_required_bridge_url(self):
+        content = (SKILL_DIR / "SKILL.md").read_text(encoding="utf-8")
+        self.assertIn("${HERMES_SKILL_DIR}/tools/xiaoai-tts", content)
+        self.assertIn("required_environment_variables:", content)
+        self.assertIn("OPENXIAOAI_BASE_URL", content)
+        self.assertIn("RESULT success=true completed=true", content)
+        self.assertIn("--blocking", content)
+
+    def test_native_text_api_failure_returns_nonzero(self):
+        module = _load_script("play_text")
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(module, "api_request", return_value={"success": False}),
+            mock.patch.object(sys, "argv", ["play_text.py", "测试"]),
+            redirect_stderr(stderr),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            module.main()
+
+        self.assertEqual(1, raised.exception.code)
+        self.assertIn("RESULT success=false", stderr.getvalue())
+
+    def test_doubao_api_failure_returns_nonzero(self):
+        module = _load_script("tts_doubao")
+        stderr = io.StringIO()
+        with (
+            mock.patch.object(module, "api_request", return_value={"success": False}),
+            mock.patch.object(sys, "argv", ["tts_doubao.py", "测试"]),
+            redirect_stderr(stderr),
+            self.assertRaises(SystemExit) as raised,
+        ):
+            module.main()
+
+        self.assertEqual(1, raised.exception.code)
+        self.assertIn("RESULT success=false", stderr.getvalue())
+
+    def test_blocking_native_text_reports_completed(self):
+        module = _load_script("play_text")
+        stdout = io.StringIO()
+        with (
+            mock.patch.object(module, "api_request", return_value={"success": True}),
+            mock.patch.object(
+                sys,
+                "argv",
+                ["play_text.py", "测试", "--blocking"],
+            ),
+            mock.patch("sys.stdout", stdout),
+        ):
+            module.main()
+
+        self.assertIn(
+            "RESULT success=true completed=true",
+            stdout.getvalue(),
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## 说明

为项目新增独立 Hermes Agent 后端，在通用 OpenAI-compatible 接入之外支持 Hermes 原生事件和会话能力。

## 主要改动

- Hermes 独立配置、启动和唤醒路由
- Session/Profile 管理及 capabilities 探测
- SSE 流式响应、分句 TTS、顺序播放和中断清理
- 工具进度及长等待提示
- 复用现有 Bridge API 支持 Agent 主动播报
- 补充配置文档和测试

## 测试

- `104 passed, 3 skipped`
- 已通过真实 Hermes API Server 和小爱音箱链路测试